### PR TITLE
handle removePkg exception when the package is not already present

### DIFF
--- a/python/qipkg/actions/deploy_package.py
+++ b/python/qipkg/actions/deploy_package.py
@@ -52,7 +52,11 @@ def _install_package(url, pkg_name, pkg_path):
     session = qi.Session()
     session.connect("tcp://%s:9559" % (url.host))
     package_manager = session.service("PackageManager")
-    package_manager.removePkg(pkg_name)
+    try:
+        package_manager.removePkg(pkg_name)
+    except Exception as e:
+        ui.warning("Package does not exist on target. Fresh install")
+
     ret = package_manager.install(
             "/home/%s/%s" % (url.user, os.path.basename(pkg_path)))
     ui.info("PackageManager returned: ", ret)


### PR DESCRIPTION
qipkg deploy-package will not work if a previous version of the package is not already on the target.
This is a basic fix that lets me use deploy-package again.
Message might need to be changed. Let me know.