### PR TITLE
qisrc: add support for tags

### DIFF
--- a/python/qisrc/worktree.py
+++ b/python/qisrc/worktree.py
@@ -196,7 +196,10 @@ class GitWorkTree(qisys.worktree.WorkTreeObserver):
             git.init()
             git.remote("add", remote_name, clone_url)
             git.fetch(remote_name, "--quiet")
-            git.checkout("-b", branch, "%s/%s" % (remote_name, branch))
+            remote_branch = "%s/%s" % (remote_name, branch)
+            rc, _ = git.call("rev-parse", "--verify", "--quiet", remote_branch, raises=False)
+            # When `remote_branch` is invalid, try to checkout `branch` instead
+            git.checkout("-b", branch, branch if rc else remote_branch)
         except:
             ui.error("Cloning repo failed")
             if git.is_empty():


### PR DESCRIPTION
This commit lets users specify a tag name (or even a commit hash) in the
`branch` attribute of a repo in the manifest.xml file.

This used to fail because qisrc tried to checkout `remote_name`/`branch`, which
is not valid when `branch` is actually a tag.

The proposed solution is entirely back-compatible: it will only alter the
current behavior when `remote_name`/`branch` is invalid anyway (checked with
`git rev-parse`). When this is the case, it will try to checkout `branch`
rather than `remote_name`/`branch`, which will work for tags.

refs #25