### PR TITLE
qisrc: handle relative paths

### DIFF
--- a/python/qisrc/actions/init.py
+++ b/python/qisrc/actions/init.py
@@ -32,6 +32,8 @@ def do(args):
     worktree = qisys.worktree.WorkTree(root)
     git_worktree = qisrc.worktree.GitWorkTree(worktree)
     if args.manifest_url:
+        if os.path.isdir(args.manifest_url):
+            args.manifest_url = qisys.sh.to_native_path(args.manifest_url)
         ok = git_worktree.configure_manifest(args.manifest_url,
                                         groups=args.groups,
                                         branch=args.branch,

--- a/python/qisrc/test/test_qisrc_init.py
+++ b/python/qisrc/test/test_qisrc_init.py
@@ -2,8 +2,10 @@
 ## Use of this source code is governed by a BSD-style license that can be
 ## found in the COPYING file.
 import qisys.script
+import qisrc.git
 from qisrc.test.conftest import TestGitWorkTree
 
+import os
 import pytest
 
 def test_in_new_directory(cd_to_tmpdir, git_server):
@@ -142,3 +144,14 @@ def test_explicit_worktree_root(qisrc_action, tmpdir):
     custom_worktree = tmpdir.join("custom_worktree")
     qisrc_action("init", "--worktree", custom_worktree.strpath)
     assert qisys.worktree.WorkTree(custom_worktree.strpath)
+
+def test_relative_path(qisrc_action, tmpdir):
+    git = qisrc.git.Git(str(tmpdir))
+    git.init()
+    manifest = open(str(tmpdir.join("manifest.xml")), "w")
+    manifest.write("<manifest />")
+    manifest.close()
+    git.add("manifest.xml")
+    git.commit("-m", "Initial commit")
+    qisrc_action("init", os.path.relpath(str(tmpdir)))
+    assert os.path.isfile(os.path.join(".qi", "manifests", "default", "manifest.xml"))


### PR DESCRIPTION
This commit lets users specify a relative path as the `manifest_url` argument
of `qisrc init`.

This used to fail because the actual `git fetch` is performed from
`.qi/manifests/default`, defeating the relative path.

The proposed solution is to convert relative paths to absolute ones before
passing them to configure_manifest. This is only done when the given url is
a valid local path.

refs #27