### PR TITLE
qisrc: add support for tags

### DIFF
--- a/python/qisrc/manifest.py
+++ b/python/qisrc/manifest.py
@@ -218,6 +218,7 @@ class RepoConfig(object):
         self.project = None
         self.default_branch = None
         self.default_remote_name = None
+        self.fixed_ref = False
         self.remotes = list()
         self.remote_names = None
 
@@ -327,6 +328,11 @@ class RepoConfigParser(qisys.qixml.XMLParser):
         self.target.src = src
 
         self.target.default_branch = self._root.get("branch")
+        if self._root.get("ref"):
+            if self.target.default_branch:
+                raise ManifestError("Specify either 'branch' or 'ref', but not both")
+            self.target.default_branch = self._root.get("ref")
+            self.target.fixed_ref = True
         remote_names = self._root.get("remotes")
         if remote_names is None:
             raise ManifestError("Missing 'remotes' attribute")

--- a/python/qisrc/project.py
+++ b/python/qisrc/project.py
@@ -137,7 +137,9 @@ class GitProject(object):
         self.remotes = list()
         for remote in repo.remotes:
             self.configure_remote(remote)
-        if repo.default_branch and repo.default_remote:
+        if repo.fixed_ref:
+            self.configure_branch(repo.default_branch, tracks=None, quiet=quiet)
+        elif repo.default_branch and repo.default_remote:
             self.configure_branch(repo.default_branch, tracks=repo.default_remote.name,
                                   remote_branch=repo.default_branch, default=True,
                                   quiet=quiet)
@@ -221,8 +223,9 @@ class GitProject(object):
         for remote in self.remotes:
             git.set_remote(remote.name, remote.url)
         for branch in self.branches:
-            git.set_tracking_branch(branch.name, branch.tracks,
-                                    remote_branch=branch.remote_branch)
+            if branch.tracks:
+                git.set_tracking_branch(branch.name, branch.tracks,
+                                        remote_branch=branch.remote_branch)
 
     def __deepcopy__(self, memo):
         shallow_copy = copy.copy(self)

--- a/python/qisrc/status.py
+++ b/python/qisrc/status.py
@@ -113,7 +113,7 @@ def print_state(project, max_len):
             ui.info(ui.green, "*", ui.reset,
                     ui.blue, project.project.src.ljust(max_len), ui.reset,
                     ui.green, ":", project.current_branch,
-                        "tracking", project.tracking)
+                    "tracking " + project.tracking if project.tracking else "")
         if project.ahead_manifest or project.behind_manifest:
             numcommits = _print_behind_ahead(project.behind_manifest, project.ahead_manifest)
             ui.info(ui.bold, "Your branch", ui.green, project.current_branch,

--- a/python/qisrc/test/test_manifest.py
+++ b/python/qisrc/test/test_manifest.py
@@ -321,6 +321,23 @@ def test_multiple_remotes(tmpdir):
     foo = manifest.repos[0]
     assert len(foo.remotes) == 2
 
+def test_tag_attribute(tmpdir):
+    manifest_xml = tmpdir.join("manifest.xml")
+    manifest_xml.write(""" \
+<manifest>
+  <remote name="origin" url="git@example.com" />
+  <repo project="foo/bar.git" ref="v4.6.5.0" remotes="origin" />
+  <repo project="foo/baz.git" remotes="origin" />
+</manifest>
+""")
+    manifest = qisrc.manifest.Manifest(manifest_xml.strpath)
+    assert len(manifest.repos) == 2
+    bar = manifest.repos[0]
+    baz = manifest.repos[1]
+    assert bar.default_branch == "v4.6.5.0"
+    assert bar.fixed_ref
+    assert not baz.fixed_ref
+
 def test_from_git_repo(git_server):
     git_server.create_repo("foo")
     git_server.switch_manifest_branch("devel")

--- a/python/qisrc/worktree.py
+++ b/python/qisrc/worktree.py
@@ -196,7 +196,10 @@ class GitWorkTree(qisys.worktree.WorkTreeObserver):
             git.init()
             git.remote("add", remote_name, clone_url)
             git.fetch(remote_name, "--quiet")
-            git.checkout("-b", branch, "%s/%s" % (remote_name, branch))
+            remote_branch = "%s/%s" % (remote_name, branch)
+            rc, _ = git.call("rev-parse", "--verify", "--quiet", remote_branch, raises=False)
+            # When `remote_branch` is invalid, try to checkout `branch` instead
+            git.checkout("-b", branch, branch if rc else remote_branch)
         except:
             ui.error("Cloning repo failed")
             if git.is_empty():


### PR DESCRIPTION
This adds a new attribute to <repo> tags in the manifest.xml file: `ref`.
This attribute can be used to specify a tag name (or even a raw commit hash)
to checkout, while disabling tracking. It is mutually exclusive with the
`branch` attribute.

This is a revised version of #26, taking into account the criticism I got there. Tags are no longer specified in the `branch` attribute. `qisrc status` now has sane output with respect to tags (it simply shows the tag name, without the `tracking ...` bit). `qisrc sync` no longer crashes when this feature is used.