### PR TITLE
Fix qitest with coverage in a build worktree

### DIFF
--- a/python/qitest/parsers.py
+++ b/python/qitest/parsers.py
@@ -60,14 +60,13 @@ def get_test_runner(args, build_project=None, qitest_json=None):
     if not test_project:
         if build_project:
             test_project = build_project.to_test_project()
+        else:
+            return
 
     if args.coverage and not build_project:
         raise Exception("""\
 --coverage can only be used from a qibuild CMake project
 """)
-
-    if not test_project:
-        return
 
     test_runner = qibuild.test_runner.ProjectTestRunner(test_project)
     if build_project:


### PR DESCRIPTION
Project resolution through worktree parsing could not be done as the
first case in `get_test_runners()` throws if theres no qitest.json in the
current working directory