### PR TITLE
Add coverage html report

### DIFF
--- a/doc/source/changes/3.11.rst
+++ b/doc/source/changes/3.11.rst
@@ -83,6 +83,7 @@ qitest
 * Implement ``qitest run --last-failed`` to re-run previously failing tests
 * Implement ``qitest run --exclude`` to specify pattern of test name to exclude from the run
 * Implement ``qitest run --ignore-timeouts`` to ignore test timeouts set from CMake code.
+* Add HTML report generation when using ``qitest run --coverage``
 
 qitoolchain
 ------------

--- a/python/qibuild/gcov.py
+++ b/python/qibuild/gcov.py
@@ -7,19 +7,21 @@ import qisys
 from qisys import ui
 
 
-def generate_coverage_xml_report(project):
-    """ Generate a XML coverage report
+def generate_coverage_reports(project):
+    """ Generate XML and HTML coverage reports
     """
     bdir = project.build_directory
     sdir = project.path
-    base_report = os.path.join(bdir, project.name + ".xml")
-    cmd = ["gcovr",
-            "--root", sdir,
-            "--exclude", ".*test.*",
-            "--exclude", ".*external.*",
-            "--exclude", ".*example.*",
-            "--xml",
-            "--output", base_report]
-    qisys.command.call(cmd, cwd=sdir, quiet=True)
-    ui.info(ui.green, "*", ui.reset, "Generated XML coverage report in",
-            ui.reset, ui.bold, base_report)
+    formats = {"xml": ["--xml"],
+               "html": ["--html", "--html-details"]}
+    for fmt, opts in formats.iteritems():
+        base_report = os.path.join(bdir, project.name + "." + fmt)
+        cmd = ["gcovr",
+                "--root", sdir,
+                "--exclude", ".*test.*",
+                "--exclude", ".*external.*",
+                "--exclude", ".*example.*"] + opts + \
+               ["--output", base_report]
+        qisys.command.call(cmd, cwd=sdir, quiet=True)
+        ui.info(ui.green, "*", ui.reset, "Generated", fmt.upper(),
+                "coverage report in", ui.reset, ui.bold, base_report)

--- a/python/qibuild/test/test_coverage.py
+++ b/python/qibuild/test/test_coverage.py
@@ -13,13 +13,16 @@ import qibuild.test
 import qibuild.gcov
 
 
-def test_generate_xml(qibuild_action):
+def test_generate_reports(qibuild_action):
     gcovr = qisys.command.find_program("gcovr", raises=False)
     if not gcovr:
         return
     proj = qibuild_action.add_test_project("cov")
     qibuild_action("configure", "cov", "--coverage")
     qibuild_action("make", "cov")
-    qibuild.gcov.generate_coverage_xml_report(proj)
-    expected_path = os.path.join(proj.build_directory, proj.name + ".xml")
-    assert os.path.exists(expected_path)
+    qibuild.gcov.generate_coverage_reports(proj)
+    expected_path_xml = os.path.join(proj.build_directory, proj.name + ".xml")
+    expected_path_html = os.path.join(proj.build_directory, proj.name + ".html")
+    assert os.path.exists(expected_path_xml)
+    assert os.path.exists(expected_path_html)
+

--- a/python/qitest/actions/run.py
+++ b/python/qitest/actions/run.py
@@ -36,7 +36,7 @@ def do(args):
         if args.coverage:
             build_worktree = qibuild.parsers.get_build_worktree(args, verbose=False)
             build_project = qibuild.parsers.get_one_build_project(build_worktree, args)
-            qibuild.gcov.generate_coverage_xml_report(build_project)
+            qibuild.gcov.generate_coverage_reports(build_project)
         global_res = global_res and res
     if not global_res:
         sys.exit(1)

--- a/python/qitest/parsers.py
+++ b/python/qitest/parsers.py
@@ -39,7 +39,7 @@ def test_parser(parser, with_num_jobs=True):
                        help="Repeat tests until they fail (at most N times)")
     group.add_argument("--qitest-json", dest="qitest_jsons", action="append")
     group.add_argument("--root-output-dir", dest="root_output_dir",
-                      help="Generate XML reports in the given directory " + \
+                      help="Generate XML and HTML reports in the given directory " + \
                            "(instead of build-<platform>)")
 
     group.add_argument("--no-capture", dest="capture", action="store_false")

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,7 +33,7 @@ sphinx-intl==0.9.5
 # For coverage
 cov-core==1.7
 coverage==3.6
-gcovr==2.4
+gcovr==3.2
 
 
 # For more checks, thanks pyflakes


### PR DESCRIPTION
This enables html reporting of gcovr (which is updated to 3.2 as the html feature has been introduced in this version).

I thought about a `--format FMT1 --format FMT2` switch with `--format xml` as default to keep the default behaviour, but I don't know if it really makes sense...