### PR TITLE
qitest run --coverage: fix root-output-dir option

### DIFF
--- a/doc/source/changes/3.11.rst
+++ b/doc/source/changes/3.11.rst
@@ -82,6 +82,7 @@ qitest
 * Implement ``qitest run --ignore-timeouts`` to ignore test timeouts set from CMake code.
 
 * ``qitest run --coverage``: also generate HTML output (requires ``gcovr >= 3.2``)
+* ``qitest run --coverage``: fix ``--root-output-dir`` option that was not used
 
 qitoolchain
 ------------

--- a/python/qibuild/gcov.py
+++ b/python/qibuild/gcov.py
@@ -7,15 +7,15 @@ import qisys
 from qisys import ui
 
 
-def generate_coverage_reports(project):
+def generate_coverage_reports(project, root_output_dir=None):
     """ Generate XML and HTML coverage reports
     """
-    bdir = project.build_directory
+    outdir = root_output_dir or project.build_directory
     sdir = project.path
     formats = {"xml": ["--xml"],
                "html": ["--html", "--html-details"]}
     for fmt, opts in formats.iteritems():
-        base_report = os.path.join(bdir, project.name + "." + fmt)
+        base_report = os.path.join(outdir, project.name + "." + fmt)
         cmd = ["gcovr",
                 "--root", sdir,
                 "--exclude", ".*test.*",

--- a/python/qibuild/test/test_coverage.py
+++ b/python/qibuild/test/test_coverage.py
@@ -26,3 +26,9 @@ def test_generate_reports(qibuild_action):
     assert os.path.exists(expected_path_xml)
     assert os.path.exists(expected_path_html)
 
+    qibuild.gcov.generate_coverage_reports(proj, root_output_dir=proj.path)
+    expected_path_xml = os.path.join(proj.path, proj.name + ".xml")
+    expected_path_html = os.path.join(proj.path, proj.name + ".html")
+    assert os.path.exists(expected_path_xml)
+    assert os.path.exists(expected_path_html)
+

--- a/python/qitest/actions/run.py
+++ b/python/qitest/actions/run.py
@@ -36,7 +36,7 @@ def do(args):
         if args.coverage:
             build_worktree = qibuild.parsers.get_build_worktree(args, verbose=False)
             build_project = qibuild.parsers.get_one_build_project(build_worktree, args)
-            qibuild.gcov.generate_coverage_reports(build_project)
+            qibuild.gcov.generate_coverage_reports(build_project, root_output_dir=args.root_output_dir)
         global_res = global_res and res
     if not global_res:
         sys.exit(1)


### PR DESCRIPTION
The value set when using the --root-output-dir option was not used when
generating coverage reports.