### PR TITLE
Add --coverage-output-dir option to qitest run

### DIFF
--- a/doc/source/changes/3.11.rst
+++ b/doc/source/changes/3.11.rst
@@ -82,6 +82,10 @@ qitest
 * Implement ``qitest run --ignore-timeouts`` to ignore test timeouts set from CMake code.
 
 * ``qitest run --coverage``: also generate HTML output (requires ``gcovr >= 3.2``)
+* ``qitest run --coverage``: add ``--coverage-output-dir`` option to set coverage output
+  directory
+* ``qitest run``: add ``--test-output-dir`` option to set test output
+  directory (``--root-output-directory`` is now deprecated)
 
 qitoolchain
 ------------

--- a/python/qibuild/gcov.py
+++ b/python/qibuild/gcov.py
@@ -6,16 +6,18 @@ import os
 import qisys
 from qisys import ui
 
-
-def generate_coverage_reports(project):
+def generate_coverage_reports(project, output_dir=None):
     """ Generate XML and HTML coverage reports
     """
-    bdir = project.build_directory
+    outdir = output_dir or os.path.join(project.sdk_directory, "coverage-results")
     sdir = project.path
+    # Make sure output dir exist and is empty:
+    qisys.sh.rm(outdir)
+    qisys.sh.mkdir(outdir, recursive=True)
     formats = {"xml": ["--xml"],
                "html": ["--html", "--html-details"]}
     for fmt, opts in formats.iteritems():
-        base_report = os.path.join(bdir, project.name + "." + fmt)
+        base_report = os.path.join(outdir, project.name + "." + fmt)
         cmd = ["gcovr",
                 "--root", sdir,
                 "--exclude", ".*test.*",

--- a/python/qibuild/test/test_coverage.py
+++ b/python/qibuild/test/test_coverage.py
@@ -21,8 +21,14 @@ def test_generate_reports(qibuild_action):
     qibuild_action("configure", "cov", "--coverage")
     qibuild_action("make", "cov")
     qibuild.gcov.generate_coverage_reports(proj)
-    expected_path_xml = os.path.join(proj.build_directory, proj.name + ".xml")
-    expected_path_html = os.path.join(proj.build_directory, proj.name + ".html")
+    expected_path_xml = os.path.join(proj.sdk_directory, "coverage-results", proj.name + ".xml")
+    expected_path_html = os.path.join(proj.sdk_directory, "coverage-results", proj.name + ".html")
+    assert os.path.exists(expected_path_xml)
+    assert os.path.exists(expected_path_html)
+
+    qibuild.gcov.generate_coverage_reports(proj, output_dir=proj.path)
+    expected_path_xml = os.path.join(proj.path, proj.name + ".xml")
+    expected_path_html = os.path.join(proj.path, proj.name + ".html")
     assert os.path.exists(expected_path_xml)
     assert os.path.exists(expected_path_html)
 

--- a/python/qibuild/test_runner.py
+++ b/python/qibuild/test_runner.py
@@ -34,22 +34,22 @@ class ProjectTestRunner(qitest.runner.TestSuiteRunner):
 
     @property
     def test_results_dir(self):
-        if self.root_output_dir:
+        if self.test_output_dir:
             if self.project.name:
-                base = os.path.join(self.root_output_dir, self.project.name)
+                base = os.path.join(self.test_output_dir, self.project.name)
             else:
-                base = self.root_output_dir
+                base = self.test_output_dir
         else:
             base = self.project.sdk_directory
         return os.path.join(base, "test-results")
 
     @property
     def perf_results_dir(self):
-        if self.root_output_dir:
+        if self.test_output_dir:
             if self.project.name:
-                base = os.path.join(self.root_output_dir, self.project.name)
+                base = os.path.join(self.test_output_dir, self.project.name)
             else:
-                base = self.root_output_dir
+                base = self.test_output_dir
         else:
             base = self.project.sdk_directory
         return os.path.join(base, "perf-results")

--- a/python/qitest/actions/run.py
+++ b/python/qitest/actions/run.py
@@ -36,7 +36,7 @@ def do(args):
         if args.coverage:
             build_worktree = qibuild.parsers.get_build_worktree(args, verbose=False)
             build_project = qibuild.parsers.get_one_build_project(build_worktree, args)
-            qibuild.gcov.generate_coverage_reports(build_project)
+            qibuild.gcov.generate_coverage_reports(build_project, output_dir=args.coverage_output_dir)
         global_res = global_res and res
     if not global_res:
         sys.exit(1)

--- a/python/qitest/parsers.py
+++ b/python/qitest/parsers.py
@@ -38,9 +38,14 @@ def test_parser(parser, with_num_jobs=True):
     group.add_argument("--repeat-until-fail", default=0, type=int, metavar="N",
                        help="Repeat tests until they fail (at most N times)")
     group.add_argument("--qitest-json", dest="qitest_jsons", action="append")
-    group.add_argument("--root-output-dir", dest="root_output_dir",
-                      help="Generate XML and HTML reports in the given directory " + \
-                           "(instead of build-<platform>)")
+    group.add_argument("--test-output-dir", dest="test_output_dir",
+                      help="Generate XML test reports in the given directory " + \
+                           "(instead of build-<platform>/sdk/test-results)")
+    group.add_argument("--coverage-output-dir", dest="coverage_output_dir",
+                      help="Generate XML and HTML coverage reports in the given " + \
+                           "directory (instead of build-<platform>/sdk/coverage-results)")
+    group.add_argument("--root-output-dir", dest="test_output_dir", metavar="ROOT_OUTPUT_DIR",
+                      help="same as --test-output-dir (deprecated)")
 
     group.add_argument("--no-capture", dest="capture", action="store_false")
     group.add_argument("--ignore-timeouts", dest="ignore_timeouts", action="store_true",
@@ -94,7 +99,7 @@ def get_test_runner(args, build_project=None, qitest_json=None):
     test_runner.repeat_until_fail = args.repeat_until_fail
     test_runner.nightly = args.nightly
     test_runner.nightmare = args.nightmare
-    test_runner.root_output_dir = args.root_output_dir
+    test_runner.test_output_dir = args.test_output_dir
     test_runner.capture = args.capture
     test_runner.last_failed = args.last_failed
     test_runner.ignore_timeouts = args.ignore_timeouts

--- a/python/qitest/runner.py
+++ b/python/qitest/runner.py
@@ -26,7 +26,7 @@ class TestSuiteRunner(object):
         self.nightly = False
         self.coverage = False
         self.nightmare = False
-        self.root_output_dir = None
+        self.test_output_dir = None
         self.capture = True
         self.last_failed = False
         self._tests = project.tests


### PR DESCRIPTION
The default path is also defaulted to
`build-<platform>/sdk/coverage-results` to be consistent with the existing
qitest output

The description for `--root-output-dir` in `qitest run --help` is also fixed