### PR TITLE
support for tags (and sha1) in qisrc manifest

### DIFF
--- a/doc/source/advanced/cfg/qisrc_manifest_syntax.rst
+++ b/doc/source/advanced/cfg/qisrc_manifest_syntax.rst
@@ -111,7 +111,7 @@ If ``src`` is not given, it will deduced from the project name.
    <manifest>
       <remote name="origin" url="git://example.com" />
       <remote name="gerrit" url="ssh://review.corp.com:29418" review="true" />
-      <project name="bar/baz.git" remotes="origin gerrit" />
+      <repo project="bar/baz.git" remotes="origin gerrit" />
     </manifest>
 
 
@@ -123,7 +123,32 @@ The repository will be configured with two remotes: ``origin``, and ``gerrit``,
 and the ``commit-msg`` gerrit hook will be fetched automatically from
 ``<username>@<server>:hooks/commit-msg`` on the given port .
 
+The repository will be cloned using the URL from the first remote.
 
+Custom branch
++++++++++++++
+
+
+By default, a ``master`` branch will be created tracking the remote used for
+cloning.
+
+You can specify an other branch to use like this:
+
+.. code-block:: xml
+
+  <repo project="bar/baz.git" remotes="origin" branch="devel" />
+
+Here, a ``devel`` branch will be created, tracking ``origin/devel``
+
+Fixed reference
+++++++++++++++++
+
+Lastly, instead of a branch you can specify a fixed reference. (A tag or a SHA1)
+In this case, no branch will be configured.
+
+.. code-block:: xml
+
+    <repo project="bar/baz.git" remotes="origin" ref="v0.1" />
 
 groups node
 -----------
@@ -140,7 +165,7 @@ Then they contain a list of project name, and can include other groups.
     </group>
     <group name="core">
       <group name="testing" />
-      <project name="libcore" />
+      <project name="libcore.git" />
     </group>
   </groups>
 

--- a/doc/source/changes/3.12.rst
+++ b/doc/source/changes/3.12.rst
@@ -78,6 +78,12 @@ qisrc
   For instance, to push everything but the last commit, you can use
   ``qisrc push HEAD~1:master``
 
+* Add support for fixed refs (or tags) in qisrc manifest
+
+  .. code-block:: xml
+
+    <repo project="foo/bar.git" ref="v0.1" />
+
 * Fix ``qisrc info`` when there is no manifest
 
 cmake

--- a/python/qisrc/actions/reset.py
+++ b/python/qisrc/actions/reset.py
@@ -61,7 +61,11 @@ def do(args):
             continue
         if not git_project.default_branch:
             if git_project.fixed_ref:
-                qisrc.reset.clever_reset_ref(git_project, git_project.fixed_ref)
+                ok, mess = qisrc.reset.clever_reset_ref(
+                        git_project, git_project.fixed_ref, raises=False)
+                if not ok:
+                    errors.append(src)
+                    ui.error(mess)
                 continue
             else:
                 ui.warning(git_project.src, "not in manifest, skipping")

--- a/python/qisrc/actions/reset.py
+++ b/python/qisrc/actions/reset.py
@@ -60,8 +60,12 @@ def do(args):
             errors.append(src)
             continue
         if not git_project.default_branch:
-            ui.warning(git_project.src, "not in any manifest, skipping")
-            continue
+            if git_project.fixed_ref:
+                qisrc.reset.clever_reset_ref(git_project, git_project.fixed_ref)
+                continue
+            else:
+                ui.warning(git_project.src, "not in manifest, skipping")
+                continue
         branch = git_project.default_branch.name
         remote = git_project.default_remote.name
         git.safe_checkout(branch, remote, force=True)

--- a/python/qisrc/actions/sync.py
+++ b/python/qisrc/actions/sync.py
@@ -89,7 +89,7 @@ def do(args):
                 ui.info(ui.red, "  [failed]")
                 failed.append((git_project.src, out))
             if out:
-                print ui.indent(out + "\n\n", num=2)
+                ui.info(ui.indent(out + "\n\n", num=2))
 
             i[0] += 1
 

--- a/python/qisrc/manifest.py
+++ b/python/qisrc/manifest.py
@@ -353,6 +353,10 @@ class RepoConfigParser(qisys.qixml.XMLParser):
 
         self.target.default_branch = self._root.get("branch")
         self.target.fixed_ref = self._root.get("ref")
+        if self.target.fixed_ref and self.target.default_branch:
+            mess = "Error when parsing project %s\n" % self.target.project
+            mess += "'branch' and 'ref' are mutually exclusive"
+            raise ManifestError(mess)
         remote_names = self._root.get("remotes")
         if remote_names is None:
             raise ManifestError("Missing 'remotes' attribute")

--- a/python/qisrc/reset.py
+++ b/python/qisrc/reset.py
@@ -8,7 +8,7 @@ from qisys import ui
 import qisrc.git
 
 
-def clever_reset_ref(git_project, ref):
+def clever_reset_ref(git_project, ref, raises=True):
     """ Resets only if needed, fetches only if needed """
     try:
         remote_name = git_project.default_remote.name
@@ -19,16 +19,42 @@ def clever_reset_ref(git_project, ref):
 
     git = qisrc.git.Git(git_project.path)
     if ref.startswith("refs/"):
-        git.fetch(remote_name, ref)
-        git.reset("--hard", "FETCH_HEAD")
-        return
+        if raises:
+            git.fetch(remote_name, ref)
+            git.reset("--hard", "FETCH_HEAD")
+            return
+        else:
+            with git.tansaction() as transaction:
+                git.fetch(remote_name, ref)
+                git.reset("--hard", "FETCH_HEAD")
+                return transaction.ok, transaction.output
+
+    rc, ref_sha1 = git.call("rev-parse", ref, raises=False)
+    if rc != 0:
+        # Maybe this is a newly pushed tag, try to fetch:
+        git.fetch(remote_name)
+        rc, ref_sha1 = git.call("rev-parse", ref, raises=False)
+        if rc != 0:
+            return False, "Could not parse %s as a valid ref" % ref
     _, actual_sha1 = git.call("rev-parse", "HEAD", raises=False)
-    if actual_sha1 == ref:  # Nothing to do
-        return
+    if actual_sha1 == ref_sha1:  # Nothing to do
+        if raises:
+            return
+        else:
+            return True, ""
     ret, _ = git.call("show", "--oneline", ref, raises=False)
     if ret == 0:  # SHA-1 exists locally
-        git.reset("--hard", ref)
+        if raises:
+            git.reset("--hard", ref)
+        else:
+            rc, out = git.reset("--hard", ref, raises=False)
+            return (rc == 0), out
     else:  # Full fetch in this case
-        git.fetch(remote_name)
-        git.reset("--hard", ref)
-
+        if raises:
+            git.fetch(remote_name)
+            git.reset("--hard", ref)
+        else:
+            with git.transaction() as transaction:
+                git.fetch(remote_name)
+                git.reset("--hard", ref)
+            return transaction.ok, transaction.output

--- a/python/qisrc/status.py
+++ b/python/qisrc/status.py
@@ -9,14 +9,30 @@ from qisys import ui
 
 def stat_tracking_remote(git, branch, tracking):
     """Check if branch is ahead and / or behind tracking."""
+    if branch is None or tracking is None:
+        return 0, 0
+    _, local_ref = git.call("rev-parse", branch, raises=False)
+    _, remote_ref = git.call("rev-parse", tracking, raises=False)
+    return stat_ahead_behind(git, local_ref, remote_ref)
+
+def stat_fixed_ref(git, remote_ref):
+    """ Check is HEAD is and and / or behind given ref. """
+    _, local_ref = git.call("rev-parse", "HEAD", raises=False)
+    return stat_ahead_behind(git, local_ref, remote_ref)
+
+def stat_ahead_behind(git, local_ref, remote_ref):
+    """ Returns a tuple (ahead, behind) describing how far
+    from the remote ref the local ref is
+
+    """
     behind = 0
     ahead = 0
     (ret, out) = git.call("rev-list", "--left-right",
-                          "%s..%s" % (tracking, branch), raises=False)
+                          "%s..%s" % (remote_ref, local_ref), raises=False)
     if ret == 0:
         ahead = len(out.split())
     (ret, out) = git.call("rev-list", "--left-right",
-                          "%s..%s" % (branch, tracking), raises=False)
+                          "%s..%s" % (local_ref, remote_ref), raises=False)
     if ret == 0:
         behind = len(out.split())
     return (ahead, behind)
@@ -25,6 +41,7 @@ class ProjectState():
     """A class which represent a project and is cleanlyness."""
     def __init__(self, project):
         self.project         = project
+        self.fixed_ref       = None
         self.not_on_a_branch = False
         self.incorrect_proj  = False
         self.clean           = True
@@ -58,7 +75,13 @@ def check_state(project, untracked):
         state_project.valid = False
         return state_project
 
-    state_project.clean = git.is_clean(untracked = untracked)
+    state_project.clean = git.is_clean(untracked=untracked)
+    if project.fixed_ref:
+        state_project.ahead, state_project.behind = stat_fixed_ref(git, project.fixed_ref)
+        state_project.fixed_ref = project.fixed_ref
+        _set_status(git, state_project, untracked=untracked)
+        return state_project
+
     state_project.current_branch = git.get_current_branch()
     state_project.tracking = git.get_tracking_branch()
     if project.default_remote and project.default_branch:
@@ -79,15 +102,21 @@ def check_state(project, untracked):
             git, state_project.current_branch, "%s/%s" % (
             project.default_remote.name, project.default_branch.name))
 
+        _set_status(git, state_project, untracked=untracked)
+    return state_project
+
+def _set_status(git, state_project, untracked=False):
+    """ When project is not clean, display git status
+    (untracked files and the like)
+
+    """
     if not state_project.sync_and_clean:
         out = git.get_status(untracked)
         if out is not None:
             state_project.status = [ x for x in out.splitlines() if
                     len(x.strip()) > 0 ]
 
-    return state_project
-
-def _print_behind_ahead(behind, ahead):
+def print_behind_ahead(behind, ahead):
     numcommits = ""
     if behind:
        numcommits += "-" + str(behind)
@@ -99,26 +128,37 @@ def _print_behind_ahead(behind, ahead):
 
 def print_state(project, max_len):
     """Print a state project."""
-    #shortpath = os.path.relpath(project.path, qiwt.root)
-
     if project.valid:
         if project.ahead or project.behind:
-            numcommits = _print_behind_ahead(project.behind, project.ahead)
-            ui.info(ui.green, "*", ui.reset,
-                    ui.blue, project.project.src.ljust(max_len), ui.reset,
-                    ui.green, ":", project.current_branch,
-                        "tracking", ui.reset, ui.bold, ui.red, numcommits, ui.green, project.tracking)
+            numcommits = print_behind_ahead(project.behind, project.ahead)
+            if project.fixed_ref:
+                ui.info(ui.green, "*", ui.reset,
+                        ui.blue, project.project.src.ljust(max_len), ui.reset,
+                        ui.green, "fixed ref", project.fixed_ref,
+                            ui.reset, ui.bold, ui.red,
+                            numcommits)
+            else:
+                ui.info(ui.green, "*", ui.reset,
+                        ui.blue, project.project.src.ljust(max_len), ui.reset,
+                        ui.green, ":", project.current_branch,
+                            "tracking",
+                            ui.reset, ui.bold, ui.red,
+                            numcommits, ui.green, project.tracking)
         else:
-            ui.info(ui.green, "*", ui.reset,
-                    ui.blue, project.project.src.ljust(max_len), ui.reset,
-                    ui.green, ":", project.current_branch,
-                        "tracking", project.tracking)
+            if project.fixed_ref:
+                ui.info(ui.green, "*", ui.reset,
+                        ui.blue, project.project.src.ljust(max_len), ui.reset,
+                        ui.green, "fixed ref", project.fixed_ref)
+            else:
+                ui.info(ui.green, "*", ui.reset,
+                        ui.blue, project.project.src.ljust(max_len), ui.reset,
+                        ui.green, ":", project.current_branch,
+                            "tracking", project.tracking)
         if project.ahead_manifest or project.behind_manifest:
-            numcommits = _print_behind_ahead(project.behind_manifest, project.ahead_manifest)
+            numcommits = print_behind_ahead(project.behind_manifest, project.ahead_manifest)
             ui.info(ui.bold, "Your branch", ui.green, project.current_branch,
                     ui.reset, ui.bold, "is", numcommits, "commits from branch",
                     ui.blue, project.manifest_branch)
-
 
     if not project.sync_and_clean:
         if project.status is not None:

--- a/python/qisrc/test/conftest.py
+++ b/python/qisrc/test/conftest.py
@@ -225,6 +225,14 @@ class TestGitServer(object):
         self.push_manifest("%s on %s" % (repo.project, new_branch))
         self.manifest.load()
 
+    def set_fixed_ref(self, project, ref):
+        repo = self.get_repo(project)
+        repo.fixed_ref = ref
+        repo.default_branch = None
+        self.manifest.dump()
+        self.push_manifest("%s using fixed ref %s" % (repo.project, ref))
+        self.manifest.load()
+
     def push_file(self, project, filename, contents,
                   branch="master", fast_forward=True,
                   message=None):

--- a/python/qisrc/test/conftest.py
+++ b/python/qisrc/test/conftest.py
@@ -299,6 +299,10 @@ class TestGit(qisrc.git.Git):
         """ Read the contents of a file """
         return self.root.join(path).read()
 
+    def write_file(self, path, contents):
+        """ Write the given contents to the file """
+        self.root.join(path).write(contents)
+
     def commit_file(self, path, contents, message=None):
         """ Commit a file. Path will be created if it does not exits """
         file_path = self.root.join(path)

--- a/python/qisrc/test/conftest.py
+++ b/python/qisrc/test/conftest.py
@@ -254,6 +254,13 @@ class TestGitServer(object):
         else:
             git.push("origin", "--force", "%s:%s" % (branch, branch))
 
+    def push_tag(self, project, tag_name):
+        src = project.replace(".git", "")
+        repo_src = self.src.join(src)
+        git = qisrc.git.Git(repo_src.strpath)
+        git.call("tag", tag_name)
+        git.push("origin", tag_name)
+
     def delete_file(self, project, filename):
         """ Delete a file from the repository """
         src = project.replace(".git", "")

--- a/python/qisrc/test/test_fixture.py
+++ b/python/qisrc/test/test_fixture.py
@@ -111,6 +111,13 @@ def test_push_tags(git_server, tmpdir):
         foo_git.read_file("b.txt")
     assert foo_git.read_file("a.txt") == "a"
 
+def test_fixed_ref(git_server, tmpdir):
+    git_server.create_repo("foo.git")
+    git_server.set_fixed_ref("foo.git", "v0.1")
+    foo_repo = git_server.get_repo("foo.git")
+    assert foo_repo.default_branch is None
+    assert foo_repo.fixed_ref == "v0.1"
+
 def test_create_svn_repo(svn_server, tmpdir):
     foo_url = svn_server.create_repo("foo")
     work = tmpdir.mkdir("work")

--- a/python/qisrc/test/test_fixture.py
+++ b/python/qisrc/test/test_fixture.py
@@ -4,7 +4,10 @@
 import os
 import qisrc.git
 
+import pytest
+
 from qibuild.test.conftest import TestBuildWorkTree
+from qisrc.test.conftest import TestGit
 
 def test_git_server_creates_valid_urls(tmpdir, git_server):
     origin_url = git_server.manifest.get_remote("origin").url
@@ -91,6 +94,22 @@ def test_change_branch(git_server):
     git_server.change_branch("foo.git", "devel")
     foo_repo = git_server.get_repo("foo.git")
     assert foo_repo.default_branch == "devel"
+
+def test_push_tags(git_server, tmpdir):
+    foo_repo = git_server.create_repo("foo.git")
+    foo_url = foo_repo.clone_url
+    git_server.push_file("foo.git", "a.txt", "a")
+    git_server.push_tag("foo.git", "v0.1")
+    git_server.push_file("foo.git", "b.txt", "b")
+    foo = tmpdir.mkdir("foo")
+    foo_git = TestGit(foo.strpath)
+    foo_git.clone(foo_url)
+    assert foo_git.read_file("b.txt") == "b"
+    foo_git.reset("--hard", "v0.1")
+    #pylint:disable-msg=E1101
+    with pytest.raises(Exception):
+        foo_git.read_file("b.txt")
+    assert foo_git.read_file("a.txt") == "a"
 
 def test_create_svn_repo(svn_server, tmpdir):
     foo_url = svn_server.create_repo("foo")

--- a/python/qisrc/test/test_manifest.py
+++ b/python/qisrc/test/test_manifest.py
@@ -315,6 +315,22 @@ def test_multiple_remotes(tmpdir):
     foo = manifest.repos[0]
     assert len(foo.remotes) == 2
 
+def test_fixed_ref(tmpdir):
+    manifest_xml = tmpdir.join("manifest.xml")
+    manifest_xml.write(""" \
+<manifest>
+  <remote name="origin" url="git@example.com" />
+  <repo project="foo/bar.git"
+        src="lib/bar"
+        remotes="origin"
+        ref="v0.1" />
+</manifest>
+""")
+    manifest = qisrc.manifest.Manifest(manifest_xml.strpath)
+    foo = manifest.repos[0]
+    assert foo.default_branch is None
+    assert foo.fixed_ref == "v0.1"
+
 def test_from_git_repo(git_server):
     git_server.create_repo("foo")
     git_server.switch_manifest_branch("devel")

--- a/python/qisrc/test/test_manifest.py
+++ b/python/qisrc/test/test_manifest.py
@@ -331,6 +331,23 @@ def test_fixed_ref(tmpdir):
     assert foo.default_branch is None
     assert foo.fixed_ref == "v0.1"
 
+def test_fixed_ref_and_branch_are_exclusive(tmpdir):
+    manifest_xml = tmpdir.join("manifest.xml")
+    manifest_xml.write(""" \
+<manifest>
+  <remote name="origin" url="git@example.com" />
+  <repo project="foo/bar.git"
+        src="lib/bar"
+        remotes="origin"
+        ref="v0.1"
+        branch="master" />
+</manifest>
+""")
+    # pylint: disable-msg=E1101
+    with pytest.raises(Exception)as e:
+        qisrc.manifest.Manifest(manifest_xml.strpath)
+    assert "'branch' and 'ref' are mutually exclusive" in e.value.args[0]
+
 def test_from_git_repo(git_server):
     git_server.create_repo("foo")
     git_server.switch_manifest_branch("devel")

--- a/python/qisrc/test/test_qisrc_init.py
+++ b/python/qisrc/test/test_qisrc_init.py
@@ -3,6 +3,8 @@
 ## found in the COPYING file.
 import qisys.script
 import qisrc.git
+
+from qisrc.test.conftest import TestGit
 from qisrc.test.conftest import TestGitWorkTree
 
 import os
@@ -178,3 +180,17 @@ def test_all(qisrc_action, git_server):
     qisrc_action("init", git_server.manifest_url, "--all")
     git_worktree = TestGitWorkTree()
     assert len(git_worktree.git_projects) == 3
+
+def test_tags(qisrc_action, git_server):
+    git_server.create_repo("foo.git")
+    git_server.push_file("foo.git", "a.txt", "a")
+    git_server.push_tag("foo.git", "v0.1")
+    git_server.push_file("foo.git", "b.txt", "b")
+    git_server.set_fixed_ref("foo.git", "v0.1")
+    qisrc_action("init", git_server.manifest_url)
+    git_worktree = TestGitWorkTree()
+    foo_proj = git_worktree.get_git_project("foo")
+    git = TestGit(foo_proj.path)
+    actual_sha1 = git.get_ref_sha1("refs/heads/master")
+    expected_sha1 = git.get_ref_sha1("refs/tags/v0.1")
+    assert actual_sha1 == expected_sha1

--- a/python/qisrc/test/test_qisrc_reset.py
+++ b/python/qisrc/test/test_qisrc_reset.py
@@ -91,6 +91,20 @@ def test_no_files_in_repo(qisrc_action, git_server):
     qisrc_action("init", git_server.manifest_url)
     qisrc_action("reset")
 
+def test_fixed_ref(qisrc_action, git_server):
+    git_server.create_repo("foo.git")
+    git_server.push_tag("foo.git", "v0.1")
+    git_server.set_fixed_ref("foo.git", "v0.1")
+    qisrc_action("init", git_server.manifest_url)
+    git_worktree = TestGitWorkTree()
+    foo_proj = git_worktree.get_git_project("foo")
+    git = TestGit(foo_proj.path)
+    git.commit_file("a.txt", "a", "test")
+    qisrc_action("reset")
+    _, actual = git.call("rev-parse", "HEAD", raises=False)
+    _, expected = git.call("rev-parse", "v0.1", raises=False)
+    assert actual == expected
+
 def test_ignore_groups(qisrc_action, git_server):
     git_server.create_group("a", ["a.git"])
     git_server.create_group("b", ["b.git"])

--- a/python/qisrc/test/test_qisrc_status.py
+++ b/python/qisrc/test/test_qisrc_status.py
@@ -55,3 +55,27 @@ def test_not_on_any_branch(qisrc_action, record_messages):
     foo_git.checkout(out)
     qisrc_action("status")
     assert record_messages.find("not on any branch")
+
+def test_fixed_ref_up_to_date(qisrc_action, git_server, record_messages):
+    git_server.create_repo("foo.git")
+    git_server.push_tag("foo.git", "v0.1")
+    git_server.set_fixed_ref("foo.git", "v0.1")
+    qisrc_action("init", git_server.manifest_url)
+    qisrc_action("status")
+    assert record_messages.find("foo fixed ref v0.1")
+    record_messages.reset()
+    qisrc_action("status", "--short")
+    assert not record_messages.find("fixed ref")
+
+def test_fixed_ref_behind(qisrc_action, git_server, record_messages):
+    git_server.create_repo("foo.git")
+    git_server.push_file("foo.git", "a.txt", "a")
+    git_server.push_tag("foo.git", "v0.1")
+    git_server.set_fixed_ref("foo.git", "v0.1")
+    qisrc_action("init", git_server.manifest_url)
+    git_worktree = TestGitWorkTree()
+    foo_proj = git_worktree.get_git_project("foo")
+    git = qisrc.git.Git(foo_proj.path)
+    git.call("reset", "--hard", "HEAD~1")
+    qisrc_action("status")
+    assert record_messages.find("fixed ref v0.1 -1")

--- a/python/qisrc/worktree.py
+++ b/python/qisrc/worktree.py
@@ -189,6 +189,7 @@ class GitWorkTree(qisys.worktree.WorkTreeObserver):
 
     def _clone_missing(self, git_project, repo):
         branch = repo.default_branch
+        fixed_ref = repo.fixed_ref
         clone_url = repo.clone_url
         qisys.sh.mkdir(git_project.path, recursive=True)
         git = qisrc.git.Git(git_project.path)
@@ -197,7 +198,10 @@ class GitWorkTree(qisys.worktree.WorkTreeObserver):
             git.init()
             git.remote("add", remote_name, clone_url)
             git.fetch(remote_name, "--quiet")
-            git.checkout("-b", branch, "%s/%s" % (remote_name, branch))
+            if branch:
+                git.checkout("-b", branch, "%s/%s" % (remote_name, branch))
+            if fixed_ref:
+                git.reset("--hard", fixed_ref)
         if not transaction.ok:
             ui.error("Cloning repo failed")
             ui.error(transaction.output)

--- a/python/qisrc/worktree.py
+++ b/python/qisrc/worktree.py
@@ -193,13 +193,14 @@ class GitWorkTree(qisys.worktree.WorkTreeObserver):
         qisys.sh.mkdir(git_project.path, recursive=True)
         git = qisrc.git.Git(git_project.path)
         remote_name = repo.default_remote.name
-        try:
+        with git.transaction() as transaction:
             git.init()
             git.remote("add", remote_name, clone_url)
             git.fetch(remote_name, "--quiet")
             git.checkout("-b", branch, "%s/%s" % (remote_name, branch))
-        except:
+        if not transaction.ok:
             ui.error("Cloning repo failed")
+            ui.error(transaction.output)
             if git.is_empty():
                 qisys.sh.rm(git_project.path)
             self.worktree.remove_project(repo.src)


### PR DESCRIPTION
New syntax is

```xml
<repo project="foo/bar.git" ref="v0.1" />
```

This an improvement over #34 , and fixes #25 