### PR TITLE
Rewrite exceptions handling

### DIFF
--- a/doc/source/hacking/contrib/python/coding_guide.rst
+++ b/doc/source/hacking/contrib/python/coding_guide.rst
@@ -665,7 +665,7 @@ messages.
         with open(config_file, "w") as fp:
             config = fp.read()
     except IOError, err:
-        raise Exception("Could not open config file for writing")
+        raise qisys.error.Error("Could not open config file for writing")
 
   It's not helpful at all! It does not answer those basic questions:
 
@@ -684,7 +684,7 @@ messages.
     except IOError, err:
         mess = "Could not open config '%s' file for writing\n" % config_file
         mess += "Error was: %s" % err
-        raise Exception(mess)
+        raise qisys.error.Error(mess)
 
   So the error message would then be::
 

--- a/doc/source/hacking/contrib/python/coding_guide.rst
+++ b/doc/source/hacking/contrib/python/coding_guide.rst
@@ -338,6 +338,21 @@ add some spam to the eggs somewhere else :)
 * If you want to shorten the name of a module, you can use ``as alias_name`` to
   rename it, but then you must keep it consistent across your whole project.
 
+.. _qibuild-actions-libraries:
+
+Actions and libraries
+^^^^^^^^^^^^^^^^^^^^^
+
+* The code in ``qiBuild`` is divided between "actions" (the code in
+  ``*/actions/*.py`` and "libraries" (everything else).
+
+  The libraries are unit-tested, the actions are tested with integration
+  tests.
+
+  So, for instance ``qibuild.actions.foo`` may use ``do_foo`` in
+  ``qibuild.foo``. There will be unit tests for ``qibuild.foo`` in
+  ``qibuild/test/test_foo.py``, and integration tests for the
+  action in ``qibuild/test/test_qibuild_foo.py``
 
 Classes
 ^^^^^^^^

--- a/doc/source/hacking/contrib/writing_new_tests.rst
+++ b/doc/source/hacking/contrib/writing_new_tests.rst
@@ -161,21 +161,36 @@ to display error messages to the end users.
 
      try:
           module.do()
-     except Exception as e:
+     except qisys.error.Error as e:
+          # "normal" exception raise, display it in red
+          # and exit
           ui.error(str(e))
+     except SystemExit as e:
+          # sys.exit or ui.fatal called, assume
+          # error message has already been displayed
+          # and exit
+          sys.exit(e.code)
+     except:
+          # Unexpected except raises:
+          # Generate a bug report
 
 
 So it's important to check the correctness of
 the error message.
 
-This is how to do it:
+Also, all exceptions raised by qibuild should
+derive from ``qisys.error.Error``
+in order to identify unexpected errors.
+
+This is how you should test the exception
+you raise:
 
 .. code-block:: python
 
     import pytest
 
     # pylint: disable-msg=E1101
-    with pytest.raises(Exception) as e:
+    with pytest.raises(qisys.error.Error) as e:
         do_something_that_should_raise()
     assert "Bad input"  in e.value.message
 

--- a/doc/source/hacking/contrib/writing_new_tests.rst
+++ b/doc/source/hacking/contrib/writing_new_tests.rst
@@ -84,6 +84,7 @@ Basically, inside the code of an action, you should just:
 * Initialize a few objects
 * Call some methods from an other package.
 
+See also :ref:`qibuild-actions-libraries` section in the coding guide.
 
 Use dependency injection when possible
 --------------------------------------
@@ -152,8 +153,22 @@ Then in your test, you can do something like:
 Testing exceptions
 -------------------
 
-Most of qibuild source code use exception as a way
-to display error messages to the end users.
+There are two ways to terminate execution of ``qiBuild`` scripts,
+depending on whether you are in a library or in an action
+(see :ref:`qibuild-actions-libraries`)
+
+* In the "libraries":
+
+  * raise ``qisys.error.Error`` or a class derived from it
+
+* In the actions:
+
+  * Use ``ui.fatal()`` or ``sys.exit()``
+
+Any other termination (other type of exception being raised, or
+failed assert) means there's a bug in qiBuild and it crashed.
+
+This is how the code looks like:
 
 .. code-block:: python
 
@@ -171,18 +186,15 @@ to display error messages to the end users.
           # and exit
           sys.exit(e.code)
      except:
-          # Unexpected except raises:
+          # Unexpected exception raised
           # Generate a bug report
 
+This means it is important to check the correctness of
+the error message and its type. (See also
+the section on :ref:`qibuild-coding-guide-error-messages` in the
+coding guide)
 
-So it's important to check the correctness of
-the error message.
-
-Also, all exceptions raised by qibuild should
-derive from ``qisys.error.Error``
-in order to identify unexpected errors.
-
-This is how you should test the exception
+So this is how you should test the exception
 you raise:
 
 .. code-block:: python
@@ -205,13 +217,6 @@ Notes:
   ``py.test`` automatically rewrites the exceptions that are thrown
   during a test case, and for instance ``str(e)`` is **not** what you
   would expect ...
-
-.. seealso::
-
-  * The :ref:`qibuild-coding-guide-error-messages` section in the
-    qibuild coding guide
-
-
 
 Testing code that uses the filesystem
 -------------------------------------

--- a/python/qibuild/actions/add_config.py
+++ b/python/qibuild/actions/add_config.py
@@ -36,4 +36,4 @@ def do(args):
             build_worktree = qibuild.worktree.BuildWorkTree(worktree)
             build_worktree.set_default_config(name)
         else:
-            raise Exception("Must be in a worktree to use --default")
+            ui.fatal("Must be in a worktree to use --default")

--- a/python/qibuild/actions/config.py
+++ b/python/qibuild/actions/config.py
@@ -38,7 +38,7 @@ def show_config(args, build_worktree):
 
     is_local = args.is_local
     if is_local and not build_worktree:
-        raise Exception("Cannot use --local when not in a worktree")
+        ui.fatal("Cannot use --local when not in a worktree")
 
     qibuild_cfg = qibuild.config.QiBuildConfig()
     qibuild_cfg.read(create_if_missing=True)

--- a/python/qibuild/actions/convert.py
+++ b/python/qibuild/actions/convert.py
@@ -46,14 +46,13 @@ def name_from_xml(xml_path):
     try:
         tree.parse(xml_path)
     except Exception, e:
-        mess += str(e)
-        raise Exception(mess)
+        ui.fatal(e)
 
     # Read name
     root = tree.getroot()
     if root.tag != "project":
         mess += "Root node must be 'project'"
-        raise Exception(mess)
+        ui.fatal(mess)
     if root.get("version") == "3":
         project_elem = root.find("qbuild")
         if not project_elem:
@@ -64,7 +63,7 @@ def name_from_xml(xml_path):
     name = project_elem.get('name')
     if not name:
         mess += "'project' node must have a 'name' attribute"
-        raise Exception(mess)
+        ui.fatal(mess)
 
     return name
 

--- a/python/qibuild/actions/init.py
+++ b/python/qibuild/actions/init.py
@@ -25,7 +25,7 @@ def do(args):
     """Main entry point"""
     root = args.worktree or os.getcwd()
     if os.path.exists(os.path.join(root, '.qi')):
-        raise Exception("A .qi directory already exists here. " +
+        raise ui.fatal("A .qi directory already exists here. " +
                         "Please remove it or initialize elsewhere.")
     worktree = qisys.worktree.WorkTree(root)
     build_worktree = qibuild.worktree.BuildWorkTree(worktree)

--- a/python/qibuild/actions/open.py
+++ b/python/qibuild/actions/open.py
@@ -12,6 +12,7 @@ import subprocess
 
 from qisys import ui
 import qisys
+import qisys.error
 import qibuild.parsers
 
 SUPPORTED_IDES = ["QtCreator", "Visual Studio", "Xcode"]
@@ -25,7 +26,7 @@ def do(args):
     """Main entry point."""
     cmake_builder = qibuild.parsers.get_cmake_builder(args)
     if len(cmake_builder.projects) != 1:
-        raise Exception("This action can only work on one project")
+        ui.fatal("This action can only work on one project")
     project = cmake_builder.projects[0]
     if not os.path.exists(project.build_directory):
         ui.error("""It looks like your project has not been configured yet
@@ -53,7 +54,7 @@ def do(args):
         # Not supported (yet) IDE:
         mess  = "Invalid ide: %s\n" % ide.name
         mess += "Supported IDES are: %s" % ", ".join(SUPPORTED_IDES)
-        raise Exception(mess)
+        ui.fatal(mess)
 
 
 def get_ide(qibuild_cfg):
@@ -74,7 +75,7 @@ def get_ide(qibuild_cfg):
     if not supported_ides:
         mess  = "Found those IDEs in configuration: %s\n" % ", ".join(ide_names)
         mess += "But `qibuild open` only supports: %s\n" % ", ".join(SUPPORTED_IDES)
-        raise Exception(mess)
+        ui.fatal(mess)
 
     #  User chose a specific config and an IDE matches this config
     if qibuild_cfg.ide:
@@ -131,7 +132,7 @@ def open_qtcreator(project, qtcreator_path=None):
     subprocess.Popen(cmd)
 
 
-class OpenError(Exception):
+class OpenError(qisys.error.Error):
     def __init__(self, project, reason):
         self.project = project
         self.reason = reason

--- a/python/qibuild/actions/package.py
+++ b/python/qibuild/actions/package.py
@@ -39,7 +39,7 @@ def do(args):
 
     projects = cmake_builder.projects
     if len(projects) != 1:
-        raise Exception("This action can only work on one project")
+        ui.fatal("This action can only work on one project")
     project = projects[0]
 
     archive_name = project.name

--- a/python/qibuild/build.py
+++ b/python/qibuild/build.py
@@ -6,7 +6,8 @@
 
 """
 
-import qisys
+import qisys.command
+import qisys.error
 
 def make(build_dir, num_jobs=None, target=None):
     """ Launch make from a build dir.
@@ -51,16 +52,18 @@ def msbuild(sln_file, build_type="Debug", target=None, num_jobs=None):
 
     qisys.command.call(cmd)
 
-class BuildFailed(Exception):
+class BuildFailed(qisys.error.Error):
     def __init__(self, project):
         self.project = project
+
     def __str__(self):
         return "Error occurred when building project %s" % self.project.name
 
-class ConfigureFailed(Exception):
+class ConfigureFailed(qisys.error.Error):
     def __init__(self, project, exception=None):
         self.project = project
         self.exception = exception
+
     def __str__(self):
         mess =  "Error occurred when configuring project %s" % self.project.name
         returncode = self.exception.returncode

--- a/python/qibuild/build_config.py
+++ b/python/qibuild/build_config.py
@@ -5,6 +5,7 @@
 import os
 import platform
 
+import qisys.error
 import qisys.sh
 import qisys.qixml
 import qibuild.cmake
@@ -211,7 +212,7 @@ config in ~/.config/qi/qibuild.xml
 """
                 mess = mess.format(build_worktree=self.build_worktree,
                                 default_config=default_config)
-                raise Exception(mess)
+                raise qisys.error.Error(mess)
             self._default_config = matching_config.name
             self.set_active_config(matching_config.name)
 
@@ -235,13 +236,13 @@ config in ~/.config/qi/qibuild.xml
         self.qibuild_cfg.read()
         self.active_build_config = self.qibuild_cfg.configs.get(config_name)
         if not self.active_build_config:
-            raise Exception("No such build config: %s" % config_name)
+            raise qisys.error.Error("No such build config: %s" % config_name)
         self.qibuild_cfg.set_active_config(config_name)
         if self.active_build_config:
             self._profiles = self.active_build_config.profiles
             self.parse_profiles()
 
-class NoSuchProfile(Exception):
+class NoSuchProfile(qisys.error.Error):
     """ The profile specified by the user cannot be found """
     def __init__(self, name, known_profiles):
         self.name = name

--- a/python/qibuild/cmake/__init__.py
+++ b/python/qibuild/cmake/__init__.py
@@ -12,6 +12,7 @@ import re
 import subprocess
 
 from qisys import ui
+import qisys.error
 import qisys.command
 import qisys.sh
 import qibuild.cmake.profiling
@@ -29,7 +30,7 @@ def get_known_cmake_generators():
 Could not find cmake executable
 Please install it if necessary and re-run `qibuild config --wizard`\
 """
-        raise Exception(message)
+        raise qisys.error.Error(message)
     process = subprocess.Popen([cmake_, "--help"], stdout=subprocess.PIPE)
     (out, _err) = process.communicate()
     intersting  = False
@@ -84,7 +85,7 @@ def get_cached_var(build_dir, var, default=None):
     cmakecache = os.path.join(build_dir, "CMakeCache.txt")
     if not os.path.exists(cmakecache):
         mess  = "Could not find CMakeCache.txt in %s" % build_dir
-        raise Exception(mess)
+        raise qisys.error.Error(mess)
     res = read_cmake_cache(cmakecache)
     return res.get(var, default)
 
@@ -108,11 +109,11 @@ def cmake(source_dir, build_dir, cmake_args, env=None,
 
     """
     if not os.path.exists(source_dir):
-        raise Exception("source dir: %s does not exist, aborting")
+        qisys.error.Error("source dir: %s does not exist, aborting")
 
     if not os.path.exists(build_dir):
         mess  = "Could not find build directory: %s \n" % build_dir
-        raise Exception(mess)
+        qisys.error.Error(mess)
 
     # Always remove CMakeCache
     if clean_first:
@@ -131,7 +132,7 @@ def cmake(source_dir, build_dir, cmake_args, env=None,
         mess  = "You have run CMake from your sources\n"
         mess += "CMakeCache.txt found here: %s\n" % in_source_cache
         mess += "Please clean your sources and try again\n"
-        raise Exception(mess)
+        qisys.error.Error(mess)
 
     # Check that the root CMakeLists file is correct
     root_cmake = os.path.join(source_dir, "CMakeLists.txt")
@@ -221,7 +222,7 @@ def get_cmake_qibuild_dir():
     if not res:
         mess  = "Could not find qibuild cmake framework path\n"
         mess += "Please file a bug report with the details of your installation"
-        raise Exception(mess)
+        qisys.error.Error(mess)
     return res
 
 def find_installed_cmake_qibuild_dir(python_dir):
@@ -337,7 +338,7 @@ find_package(qibuild)
     if message:
         raise IncorrectCMakeLists(cmake_list_file, message)
 
-class IncorrectCMakeLists(Exception):
+class IncorrectCMakeLists(qisys.error.Error):
     def __init__(self, cmake_list_file, message):
         self.cmake_list_file = cmake_list_file
         self.message = message
@@ -347,4 +348,3 @@ class IncorrectCMakeLists(Exception):
         message += "(in %s)\n" % self.cmake_list_file
         message += self.message
         return message
-

--- a/python/qibuild/cmake_builder.py
+++ b/python/qibuild/cmake_builder.py
@@ -7,6 +7,7 @@ import functools
 import operator
 
 from qisys import ui
+import qisys.error
 import qisys.sh
 import qisys.remote
 import qibuild.deploy
@@ -143,7 +144,8 @@ Make sure to configure and build it first.
 Either set a host config with `qibuild set-host-config`
 Or configure the project with no config
 """
-                    raise Exception(mess.format(matching_project=matching_project.name))
+                    raise qisys.error.Error(
+                            mess.format(matching_project=matching_project.name))
             else:
                 # No project, try a package in the toolchain
                 toolchain = self.build_worktree.toolchain
@@ -355,7 +357,7 @@ Or configure the project with no config
 
         print
 
-class NotConfigured(Exception):
+class NotConfigured(qisys.error.Error):
     def __init__(self, project):
         self.project = project
 

--- a/python/qibuild/config.py
+++ b/python/qibuild/config.py
@@ -13,6 +13,7 @@ import locale
 
 from qisys import ui
 
+import qisys.error
 import qisys.qixml
 import qisys.sh
 from qisys.qixml import etree
@@ -468,7 +469,7 @@ class QiBuildConfig(object):
         except Exception, e:
             mess  = "Could not parse config from %s\n" % cfg_path
             mess += "Error was: %s" % str(e)
-            raise Exception(mess)
+            raise qisys.error.Error(mess)
 
         # Parse defaults:
         defaults_tree = self.tree.find("defaults")
@@ -593,7 +594,7 @@ class QiBuildConfig(object):
 
         """
         if not ide.name:
-            raise Exception("ide.name cannot be None")
+            raise qisys.error.Error("ide.name cannot be None")
         self.ides[ide.name] = ide
 
     def add_to_default_path(self, to_add):
@@ -665,7 +666,7 @@ class QiBuildConfig(object):
     def set_host_config(self, config_name):
         """ Set the config used to build host tools """
         if not config_name in self.configs:
-            raise Exception("No such config: %s" % config_name)
+            raise qisys.error.Error("No such config: %s" % config_name)
         # Make sure that we unset the previous 'host' config when
         # called twice with different config names
         for name, config in self.configs.iteritems():

--- a/python/qibuild/find.py
+++ b/python/qibuild/find.py
@@ -9,6 +9,7 @@
 import os
 import platform
 
+import qisys.error
 import qisys.sh
 
 def find_lib(paths, name, debug=None, expect_one=True, shared=None):
@@ -172,13 +173,13 @@ def _filter_candidates(name, candidates, expect_one=True):
     return res[0]
 
 
-class NotFound(Exception):
+class NotFound(qisys.error.Error):
     def __init__(self, name):
         self.name = name
     def __str__(self):
         return "%s not found" % self.name
 
-class MulipleFound(Exception):
+class MulipleFound(qisys.error.Error):
     def __init__(self, name, res):
         self.name = name
         self.res = res

--- a/python/qibuild/parsers.py
+++ b/python/qibuild/parsers.py
@@ -8,6 +8,7 @@
 import os
 
 from qisys import ui
+import qisys.error
 import qisys.parsers
 import qibuild.worktree
 import qibuild.cmake_builder
@@ -154,7 +155,7 @@ def get_one_build_project(build_worktree, args):
     parser = BuildProjectParser(build_worktree)
     projects = parser.parse_args(args)
     if not len(projects) == 1:
-        raise Exception("This action can only work on one project")
+        raise qisys.error.Error("This action can only work on one project")
     return projects[0]
 
 def get_dep_types(args, default=None):
@@ -187,7 +188,7 @@ def get_host_tools_builder(args):
     qibuild_cfg.read(create_if_missing=True)
     host_config = qibuild_cfg.get_host_config()
     if args.config and args.config != host_config:
-        raise Exception("""\
+        raise qisys.error.Error("""\
 Trying to get a host tools builder with the following
 build config: {config}, but the given config is not
 marked as a host config\
@@ -232,7 +233,8 @@ def get_build_config(build_worktree, args):
         user_flags = list()
         for flag_string in args.cmake_flags:
             if "=" not in flag_string:
-                raise Exception("Expecting a flag looking like -Dkey=value")
+                raise qisys.error.Error(
+                        "Expecting a flag looking like -Dkey=value")
             (key, value) = flag_string.split("=", 1)
             user_flags.append((key, value))
         build_config.user_flags = user_flags
@@ -290,7 +292,7 @@ class BuildProjectParser(qisys.parsers.AbstractProjectParser):
         project = self.build_worktree.get_build_project(project_arg, raises=True)
         return [project]
 
-class CouldNotGuessProjectName(Exception):
+class CouldNotGuessProjectName(qisys.error.Error):
     def __str__(self):
         return """
 Could not guess qibuild project name from current working directory

--- a/python/qibuild/profile.py
+++ b/python/qibuild/profile.py
@@ -8,6 +8,8 @@
 """
 
 import os
+
+import qisys.error
 import qisys.qixml
 
 class Profile:
@@ -95,12 +97,12 @@ def remove_build_profile(xml_path, name):
     if profiles is None:
         mess = "No profiled named '{name}' in {xml_path}"
         mess = mess.format(name=name, xml_path=xml_path)
-        raise Exception(mess)
+        raise qisys.error.Error(mess)
     match_elem = None
     for profile in profiles:
         if profile.get("name") == name:
             match_elem = profile
     if match_elem is None:
-        raise Exception("No such profile: " + name)
+        raise qisys.error.Error("No such profile: " + name)
     profiles.remove(match_elem)
     qisys.qixml.write(tree, xml_path)

--- a/python/qibuild/run.py
+++ b/python/qibuild/run.py
@@ -37,7 +37,7 @@ def run(projects, binary, bin_args, env=None, exec_=True):
     if not bin_path:
         bin_path = qisys.command.find_program(binary)
     if not bin_path:
-        raise Exception("Cannot find " + binary + " binary")
+        ui.fatal("Cannot find " + binary + " binary")
     cmd = [bin_path] + bin_args
     if exec_:
       ui.debug("exec", cmd)

--- a/python/qibuild/test/test_build_worktree.py
+++ b/python/qibuild/test/test_build_worktree.py
@@ -5,6 +5,7 @@
 import os
 import sys
 
+import qisys.error
 import qibuild.config
 
 from qibuild.test.conftest import TestBuildWorkTree
@@ -50,7 +51,7 @@ def test_changing_active_config_changes_projects_build_dir(cd_to_tmpdir):
 def test_project_names_are_unique(build_worktree):
     build_worktree.create_project("foo")
     # pylint: disable-msg=E1101
-    with pytest.raises(Exception) as e:
+    with pytest.raises(qisys.error.Error) as e:
         build_worktree.create_project("foo", src="bar/foo")
     assert "two projects with the same name" in str(e.value)
 

--- a/python/qibuild/test/test_cmake_builder.py
+++ b/python/qibuild/test/test_cmake_builder.py
@@ -4,6 +4,7 @@
 
 import os
 
+import qisys.error
 import qibuild.cmake_builder
 import qibuild.config
 import qibuild.parsers
@@ -94,7 +95,7 @@ def test_host_tools_no_host_config(build_worktree, fake_ctc):
     build_worktree.set_active_config("fake-ctc")
     cmake_builder = qibuild.cmake_builder.CMakeBuilder(build_worktree)
     # pylint:disable-msg=E1101
-    with pytest.raises(Exception) as e:
+    with pytest.raises(qisys.error.Error) as e:
         cmake_builder.get_host_dirs(usefootool_proj)
     assert "`qibuild set-host-config`" in e.value.message
 
@@ -105,6 +106,6 @@ def test_host_tools_host_tools_not_built(build_worktree, fake_ctc):
     build_worktree.set_active_config("fake-ctc")
     cmake_builder = qibuild.cmake_builder.CMakeBuilder(build_worktree)
     # pylint:disable-msg=E1101
-    with pytest.raises(Exception) as e:
+    with pytest.raises(qisys.error.Error) as e:
         cmake_builder.get_host_dirs(usefootool_proj)
     assert "(Using 'foo' build config)" in e.value.message

--- a/python/qibuild/test/test_parser.py
+++ b/python/qibuild/test/test_parser.py
@@ -43,7 +43,7 @@ def test_get_one_project(build_worktree, args):
         args.projects = None
         assert qibuild.parsers.get_one_build_project(build_worktree, args) == world
     # pylint: disable-msg=E1101
-    with pytest.raises(Exception) as e:
+    with pytest.raises(qisys.error.Error) as e:
         args.all = True
         qibuild.parsers.get_one_build_project(build_worktree, args)
     assert "one project" in str(e.value)

--- a/python/qibuild/test/test_project.py
+++ b/python/qibuild/test/test_project.py
@@ -4,6 +4,7 @@
 
 import os
 
+import qisys.error
 import qisys.qixml
 import qisrc.git
 import qibuild.config
@@ -33,7 +34,7 @@ def test_parse_num_jobs_happy_path(build_worktree):
 def test_parse_num_jobs_unsupported_generator(build_worktree):
     hello = build_worktree.create_project("hello")
     # pylint: disable-msg=E1101
-    with pytest.raises(Exception) as e:
+    with pytest.raises(qisys.error.Error) as e:
         hello.parse_num_jobs(3, cmake_generator="NMake Makefiles") ==  list()
     assert "-j is not supported for NMake Makefiles" in str(e.value)
 
@@ -73,7 +74,7 @@ def test_using_build_prefix(build_worktree):
 
 def test_validates_name(build_worktree):
     # pylint:disable-msg=E1101
-    with pytest.raises(Exception):
+    with pytest.raises(qisys.error.Error):
         build_worktree.create_project("foo/bar")
 
 def test_get_host_sdk_dir_no_system(build_worktree, toolchains, fake_ctc):

--- a/python/qibuild/test/test_qibuild_configure.py
+++ b/python/qibuild/test/test_qibuild_configure.py
@@ -8,6 +8,7 @@ import subprocess
 import time
 
 import qisys.command
+import qisys.error
 import qibuild.cmake
 import qibuild.config
 import qibuild.find
@@ -55,7 +56,7 @@ def test_qi_use_lib(qibuild_action):
 
     # Make sure it fails when it should
     # pylint: disable-msg=E1101
-    with pytest.raises(Exception):
+    with pytest.raises(qisys.error.Error):
         qibuild_action("configure", "uselib", "-DSHOULD_FAIL=ON")
 
 
@@ -73,7 +74,7 @@ def test_qi_stage_lib_but_really_bin(qibuild_action):
 def test_qi_stage_lib_but_no_such_target(qibuild_action):
     qibuild_action.add_test_project("stagelib")
     # pylint: disable-msg=E1101
-    with pytest.raises(Exception):
+    with pytest.raises(qisys.error.Error):
         qibuild_action("configure", "stagelib",
                        "-DSHOULD_FAIL_STAGE_NO_SUCH_TARGET")
 

--- a/python/qibuild/test/test_qibuild_init.py
+++ b/python/qibuild/test/test_qibuild_init.py
@@ -1,8 +1,12 @@
 ## Copyright (c) 2012-2016 Aldebaran Robotics. All rights reserved.
 ## Use of this source code is governed by a BSD-style license that can be
 ## found in the COPYING file.
+
 """ test qibuild init """
+
+import qisys.error
 import qisys.script
+
 import pytest
 
 
@@ -13,11 +17,12 @@ def test_works_from_an_empty_dir(tmpdir, monkeypatch):
     assert tmpdir.join(".qi").check(dir=True)
 
 
-def test_fails_if_qi_dir(tmpdir, monkeypatch):
+def test_fails_if_qi_dir(tmpdir, monkeypatch, record_messages):
     ''' negative test '''
     tmpdir.mkdir(".qi")
     monkeypatch.chdir(tmpdir)
     # pylint: disable-msg=E1101
-    with pytest.raises(Exception) as err:
+    with pytest.raises(SystemExit) as err:
         qisys.script.run_action("qibuild.actions.init")
-    assert ".qi directory" in str(err.value)
+    assert err.value.code != 0
+    assert record_messages.find(".qi directory")

--- a/python/qibuild/test/test_qibuild_set_host_config.py
+++ b/python/qibuild/test/test_qibuild_set_host_config.py
@@ -2,6 +2,7 @@
 ## Use of this source code is governed by a BSD-style license that can be
 ## found in the COPYING file.
 
+import qisys.error
 import qibuild.config
 
 import pytest
@@ -15,6 +16,6 @@ def test_set_host_config_happy_path(qibuild_action):
 
 def test_set_host_config_no_such_config(qibuild_action):
     # pylint:disable-msg=E1101
-    with pytest.raises(Exception) as e:
+    with pytest.raises(qisys.error.Error) as e:
         qibuild_action("set-host-config", "foo")
     assert "No such config" in e.value.message

--- a/python/qibuild/test/test_qibuild_stage_script.py
+++ b/python/qibuild/test/test_qibuild_stage_script.py
@@ -4,7 +4,9 @@
 import os
 import sys
 import subprocess
+
 import qisys.command
+import qisys.error
 import qibuild.find
 
 import pytest
@@ -33,7 +35,7 @@ def test_stage_script(qibuild_action, tmpdir):
     qibuild_action("install", "stagescript", tmpdir.strpath)
     # QI_PATH is only set by trampoline, so we expect next one to fail.
     # pylint: disable-msg=E1101
-    with pytest.raises(Exception):
+    with pytest.raises(qisys.error.Error):
       run_python_script(os.path.join(tmpdir.strpath, 'bin', 'check_qipath'))
     run_python_script(os.path.join(tmpdir.strpath, 'bin', 'dlopenfoo'))
     run_python_script(os.path.join(tmpdir.strpath, 'bin', 'dlopenbar'))
@@ -49,4 +51,3 @@ def test_stage_script(qibuild_action, tmpdir):
     run_python_script(os.path.join(tmpdir.strpath, 'bin', 'dlopenfoo'))
     run_python_script(os.path.join(tmpdir.strpath, 'bin', 'dlopenbar'))
     run_python_script(os.path.join(tmpdir.strpath, 'bin', 'dlopenworlduser'))
-

--- a/python/qibuild/test_runner.py
+++ b/python/qibuild/test_runner.py
@@ -7,6 +7,7 @@ import os
 import re
 import sys
 
+import qisys.error
 import qisys.sh
 from qisys import ui
 from qisys.qixml import etree
@@ -65,7 +66,7 @@ class ProjectTestRunner(qitest.runner.TestSuiteRunner):
         if not qisys.command.find_program("taskset"):
             mess = "taskset was not found on the system.\n"
             mess += "Cannot set number of CPUs used by the tests"
-            raise Exception(mess)
+            raise qisys.error.Error(mess)
         self._num_cpus = value
 
     @property
@@ -77,7 +78,7 @@ class ProjectTestRunner(qitest.runner.TestSuiteRunner):
         if not value:
             return
         if not qisys.command.find_program("valgrind"):
-            raise Exception("valgrind was not found on the system")
+            raise qisys.error.Error("valgrind was not found on the system")
         self._valgrind = value
 
     @property
@@ -89,7 +90,8 @@ class ProjectTestRunner(qitest.runner.TestSuiteRunner):
         if not value:
             return
         if not qisys.command.find_program("gcovr"):
-            raise Exception("please install gcovr in order to measure coverage")
+            raise qisys.error.Error(
+                    "please install gcovr in order to measure coverage")
         self._coverage = value
 
 
@@ -243,7 +245,7 @@ class ProcessTestLauncher(qitest.runner.TestLauncher):
 
     def _with_valgrind(self, test):
         if not qisys.command.find_program("valgrind"):
-            raise Exception("valgrind was not found on the system")
+            raise qisys.error.Error("valgrind was not found on the system")
         cwd = test["working_directory"]
         valgrind_log = self.valgrind_log(test)
         test["timeout"] = test["timeout"] * 10

--- a/python/qibuild/wizard.py
+++ b/python/qibuild/wizard.py
@@ -10,9 +10,9 @@ import os
 import sys
 
 from qisys import ui
-import qisys
-import qibuild
-import qitoolchain
+import qisys.error
+import qibuild.cmake
+import qibuild.config
 
 def guess_cmake(qibuild_cfg):
     """ Try to find cmake
@@ -28,8 +28,9 @@ def guess_cmake(qibuild_cfg):
     print "CMake not found"
     cmake = qisys.interact.ask_program("Please enter full CMake path")
     if not cmake:
-        raise Exception("qiBuild cannot work without CMake\n"
-            "Please install CMake if necessary and re-run this wizard\n")
+        raise qisys.error.Error(
+                "qiBuild cannot work without CMake\n"
+                "Please install CMake if necessary and re-run this wizard\n")
     # Add path to CMake in build env
     cmake_path = os.path.dirname(cmake)
     qibuild_cfg.add_to_default_path(cmake_path)

--- a/python/qibuild/worktree.py
+++ b/python/qibuild/worktree.py
@@ -7,6 +7,7 @@ import difflib
 
 from qisys import ui
 import qisys.command
+import qisys.error
 import qisys.worktree
 import qibuild.build
 import qibuild.build_config
@@ -215,7 +216,7 @@ class BuildWorkTree(qisys.worktree.WorkTreeObserver):
     def check_unique_name(self, new_project):
         for project in self.build_projects:
             if project.name == new_project.name:
-                raise Exception("""\
+                raise qisys.error.Error("""\
 Found two projects with the same name ({project.name})
 In:
 * {project.path}
@@ -255,10 +256,10 @@ def new_build_project(build_worktree, project):
     return build_project
 
 
-class BuildWorkTreeError(Exception):
+class BuildWorkTreeError(qisys.error.Error):
     pass
 
-class BadProjectConfig(Exception):
+class BadProjectConfig(qisys.error.Error):
     def __str__(self):
         return """
 Incorrect configuration detected for project in {0}

--- a/python/qidoc/builder.py
+++ b/python/qidoc/builder.py
@@ -4,6 +4,7 @@
 import os
 
 from qisys import ui
+import qisys.error
 import qisys.sort
 
 
@@ -137,5 +138,5 @@ class DocBuilder(object):
             if project:
                 projects.append(project)
             else:
-                raise Exception("Could not find %s dependency" % name)
+                raise qisys.error.Error("Could not find %s dependency" % name)
         return projects

--- a/python/qidoc/doxygen.py
+++ b/python/qidoc/doxygen.py
@@ -6,6 +6,8 @@
 import os
 import collections
 
+import qisys.error
+
 def read_doxyfile(doxyfile):
     """ Parse a doxyfile path.
 
@@ -39,7 +41,7 @@ def read_doxyfile(doxyfile):
                 mess = "Error when parsing Doxyfile in " + doxyfile + "\n"
                 mess += line + "\n"
                 mess += "does not match any assignment"
-                raise Exception(mess)
+                raise qisys.error.Error(mess)
             res[key.strip()] += " " + value.strip()
         elif "=" in line:
             key,  value = line.split("=", 1)

--- a/python/qidoc/parsers.py
+++ b/python/qidoc/parsers.py
@@ -3,6 +3,7 @@
 ## found in the COPYING file.
 
 from qisys import ui
+import qisys.error
 import qisys.parsers
 
 
@@ -39,7 +40,7 @@ def get_one_doc_project(doc_worktree, args):
     parser = DocProjectParser(doc_worktree)
     projects = parser.parse_args(args)
     if not len(projects) == 1:
-        raise Exception("This action can only work with one project")
+        raise qisys.error.Error("This action can only work with one project")
     return projects[0]
 
 def get_doc_builder(args):
@@ -94,7 +95,7 @@ class DocProjectParser(qisys.parsers.AbstractProjectParser):
         project = self.doc_worktree.get_doc_project(project_arg, raises=True)
         return [project]
 
-class CouldNotGuessProjectName(Exception):
+class CouldNotGuessProjectName(qisys.error.Error):
     def __str__(self):
         return """
 Could not guess doc project name from current working directory

--- a/python/qidoc/sphinx_project.py
+++ b/python/qidoc/sphinx_project.py
@@ -6,6 +6,7 @@ import sys
 
 from qisys import ui
 import qisys.archive
+import qisys.error
 import qisys.sh
 import qidoc.project
 import pprint
@@ -292,11 +293,11 @@ def get_num_spellcheck_errors(build_dir):
                  (res, output_txt))
     return res
 
-class SphinxBuildError(Exception):
+class SphinxBuildError(qisys.error.Error):
     def __str__(self):
         return "Error occurred when building doc project: %s" % self.args[0].name
 
-class UnknownLingua(Exception):
+class UnknownLingua(qisys.error.Error):
     def __init__(self, project, language):
         self.language = language
         self.project = project

--- a/python/qidoc/test/test_doxygen.py
+++ b/python/qidoc/test/test_doxygen.py
@@ -4,6 +4,7 @@
 
 import os
 
+import qisys.error
 import qidoc.doxygen
 import qidoc.builder
 from qidoc.test.conftest import find_link
@@ -33,7 +34,7 @@ FOO = 1
 BAR += 2
 """)
     # pylint: disable-msg=E1101
-    with pytest.raises(Exception) as e:
+    with pytest.raises(qisys.error.Error) as e:
         qidoc.doxygen.read_doxyfile(doxyfile.strpath)
     assert "does not match" in e.value.message
 

--- a/python/qidoc/worktree.py
+++ b/python/qidoc/worktree.py
@@ -5,6 +5,7 @@ import os
 import difflib
 
 from qisys import ui
+import qisys.error
 import qisys.worktree
 import qisys.qixml
 
@@ -40,7 +41,7 @@ class DocWorkTree(qisys.worktree.WorkTreeObserver):
             mess = "Found multiple template projects\n"
             for project in res:
                 mess += "  * " + project.path + "\n"
-            raise Exception(mess)
+            raise qisys.error.Error(mess)
         return res[0]
 
     def reload(self):
@@ -68,7 +69,7 @@ class DocWorkTree(qisys.worktree.WorkTreeObserver):
                                                       raises=False)
         # maybe the new project comes from qibuild2 compat ...
         if project_with_same_name:
-            raise Exception("""\
+            raise qisys.error.Error("""\
 Found two projects with the same name ({0})
 In:
 * {1}
@@ -192,7 +193,7 @@ def _new_doc_project(doc_worktree, project, xml_elem, doc_type):
     return doc_project
 
 
-class BadProjectConfig(Exception):
+class BadProjectConfig(qisys.error.Error):
     def __str__(self):
         return """
 Incorrect configuration detected for project in {0}

--- a/python/qilinguist/parsers.py
+++ b/python/qilinguist/parsers.py
@@ -2,6 +2,7 @@
 ## Use of this source code is governed by a BSD-style license that can be
 ## found in the COPYING file.
 
+import qisys.error
 import qisys.sh
 import qisys.parsers
 import qilinguist.builder
@@ -28,11 +29,13 @@ def get_linguist_projects(args, default_all=False):
             if worktree:
                 project_names.append(arg)
             else:
-                raise Exception("Cannot use project names when running "
-                                "outside a worktree")
-    if not worktree and not pml_paths:
-        raise Exception("You should specify at least a pml path when running "
+                raise qisys.error.Error(
+                        "Cannot use project names when running "
                         "outside a worktree")
+    if not worktree and not pml_paths:
+        raise qisys.error.Error(
+                "You should specify at least a pml path when running "
+                "outside a worktree")
     res = list()
     if worktree:
         args.projects = project_names
@@ -102,7 +105,7 @@ class LinguistProjectParser(qisys.parsers.AbstractProjectParser):
                                                               raises=True)
         return [project]
 
-class CouldNotGuessProjectName(Exception):
+class CouldNotGuessProjectName(qisys.error.Error):
     def __str__(self):
         return """
 Could not guess linguist project name from current working directory

--- a/python/qilinguist/pml_translator.py
+++ b/python/qilinguist/pml_translator.py
@@ -5,6 +5,7 @@ import os
 
 from qisys import ui
 import qisys.command
+import qisys.error
 import qisys.qixml
 
 import qilinguist.project
@@ -40,7 +41,7 @@ class PMLTranslator(qilinguist.project.LinguistProject):
             qisys.command.call(cmd)
             self.qm_files.append(output)
         if not all_ok and raises:
-            raise Exception("`qilinguist release` failed")
+            raise qisys.error.Error("`qilinguist release` failed")
         return all_ok
 
     def install(self, dest):

--- a/python/qilinguist/project.py
+++ b/python/qilinguist/project.py
@@ -4,6 +4,7 @@
 import abc
 import os
 
+import qisys.error
 import qisys.sh
 
 class LinguistProject(object):
@@ -31,7 +32,7 @@ class LinguistProject(object):
         res = os.path.join(self.po_path, "POTFILES.in")
         if not os.path.exists(res):
             mess = "No po/POTFILES.in for project {} in {}"
-            raise Exception(mess.format(self.name, self.path))
+            raise qisys.error.Error(mess.format(self.name, self.path))
         return res
 
     def get_sources(self):

--- a/python/qilinguist/qigettext.py
+++ b/python/qilinguist/qigettext.py
@@ -13,6 +13,7 @@ import subprocess
 
 from qisys import ui
 import qisys.command
+import qisys.error
 import qilinguist.project
 
 class GettextProject(qilinguist.project.LinguistProject):
@@ -66,7 +67,7 @@ class GettextProject(qilinguist.project.LinguistProject):
                 ui.error(message)
             all_ok = all_ok and ok
         if not all_ok and raises:
-            raise Exception("`qilinguist release` failed")
+            raise qisys.error.Error("`qilinguist release` failed")
         return all_ok
 
     def extract_pot_file(self):

--- a/python/qilinguist/qtlinguist.py
+++ b/python/qilinguist/qtlinguist.py
@@ -12,6 +12,7 @@ import subprocess
 
 from qisys import ui
 import qisys.command
+import qisys.error
 import qilinguist.project
 
 class QtLinguistProject(qilinguist.project.LinguistProject):
@@ -44,7 +45,7 @@ class QtLinguistProject(qilinguist.project.LinguistProject):
                 all_ok = False
                 ui.error(message)
         if not all_ok and raises:
-            raise Exception("`qilinguist release` failed")
+            raise qisys.error.Error("`qilinguist release` failed")
         return all_ok
 
     def install(self, destination):

--- a/python/qilinguist/test/test_qilinguist_parsers.py
+++ b/python/qilinguist/test/test_qilinguist_parsers.py
@@ -1,6 +1,8 @@
 ## Copyright (c) 2012-2016 Aldebaran Robotics. All rights reserved.
 ## Use of this source code is governed by a BSD-style license that can be
 ## found in the COPYING file.
+
+import qisys.error
 import qilinguist.parsers
 import qilinguist.pml_translator
 import qilinguist.qigettext
@@ -27,14 +29,14 @@ def test_parsing_pml_no_worktree(cd_to_tmpdir, tmpdir, args):
 
 def test_names_no_worktree(cd_to_tmpdir, args):
     args.projects = ["foo"]
-    with pytest.raises(Exception) as e:
+    with pytest.raises(qisys.error.Error) as e:
         qilinguist.parsers.get_linguist_projects(args)
     assert e.value.message == "Cannot use project names when running " \
                                "outside a worktree"
 
 def test_no_worktree_no_args(cd_to_tmpdir, args):
     args.projects = list()
-    with pytest.raises(Exception) as e:
+    with pytest.raises(qisys.error.Error) as e:
         qilinguist.parsers.get_linguist_projects(args)
     assert e.value.message == "You should specify at least a pml path " \
                               "when running outside a worktree"

--- a/python/qilinguist/test/test_qilinguist_release.py
+++ b/python/qilinguist/test/test_qilinguist_release.py
@@ -4,6 +4,7 @@
 
 import os
 
+import qisys.error
 import qisys.script
 
 from qibuild.test.conftest import TestBuildWorkTree
@@ -44,7 +45,7 @@ def test_pml_outside_worktree(tmpdir, monkeypatch):
 
 def test_raise_when_no_project_given_outside_a_worktree(tmpdir, monkeypatch):
     monkeypatch.chdir(tmpdir)
-    with pytest.raises(Exception) as e:
+    with pytest.raises(qisys.error.Error) as e:
         qisys.script.run_action("qilinguist.actions.release")
     assert "outside a worktree" in e.value.message
 

--- a/python/qilinguist/test/test_qt.py
+++ b/python/qilinguist/test/test_qt.py
@@ -5,6 +5,8 @@ import os
 import subprocess
 
 from qibuild.test.conftest import TestBuildWorkTree
+
+import qisys.error
 import qisys.qixml
 import qibuild.find
 
@@ -13,7 +15,7 @@ def test_qt(qilinguist_action):
     project = build_worktree.add_test_project("translateme/qt")
     try:
         project.configure()
-    except Exception:
+    except qisys.error.Error:
         print "Qt not installed, skipping"
         return
     project.build()

--- a/python/qilinguist/worktree.py
+++ b/python/qilinguist/worktree.py
@@ -5,6 +5,7 @@ import os
 
 
 from qisys import ui
+import qisys.error
 import qisys.worktree
 import qisys.qixml
 
@@ -43,7 +44,7 @@ class LinguistWorkTree(qisys.worktree.WorkTreeObserver):
         project_with_same_name = self.get_linguist_project(new_project.name,
                                                            raises=False)
         if project_with_same_name:
-            raise Exception("""\
+            raise qisys.error.Error("""\
 Found two projects with the same name ({0})
 In:
 * {1}
@@ -101,7 +102,7 @@ Choose between 'linguist' or 'gettext'
                                      linguas=linguas)
     return new_project
 
-class BadProjectConfig(Exception):
+class BadProjectConfig(qisys.error.Error):
     def __str__(self):
         return """
 Incorrect configuration detected for project in {0}

--- a/python/qipkg/actions/deploy_package.py
+++ b/python/qipkg/actions/deploy_package.py
@@ -53,7 +53,7 @@ def deploy(pkg_path, url):
     except Exception as e:
         ui.error("Unable to install package on target")
         ui.error("Error was: ", e)
-        return
+        sys.exit(1)
 
     rm_cmd = ["ssh", "%s@%s" % (url.user, url.host),
                 "rm", os.path.basename(pkg_path)]

--- a/python/qipkg/actions/validate_package.py
+++ b/python/qipkg/actions/validate_package.py
@@ -7,6 +7,7 @@ import zipfile
 import os
 
 from qisys import ui
+import qisys.error
 import qisys.parsers
 import qisys.qixml
 import qipkg.manifest
@@ -32,6 +33,6 @@ def do(args):
             ui.info(ui.green, "The package satisfies "
                               "default package requirements")
         else:
-            raise Exception("Given package does not satisfy "
-                            "default package requirements")
-
+            raise qisys.error.Error(
+                    "Given package does not satisfy "
+                    "default package requirements")

--- a/python/qipkg/builder.py
+++ b/python/qipkg/builder.py
@@ -8,6 +8,7 @@ import tempfile
 import zipfile
 
 from qisys import ui
+import qisys.error
 import qisys.qixml
 import qibuild.breakpad
 import qibuild.worktree
@@ -23,12 +24,12 @@ class PMLBuilder(object):
     """ Build a package from a pml file """
     def __init__(self, pml_path, worktree=None):
         if not os.path.exists(pml_path):
-            raise Exception("%s does not exist" % pml_path)
+            raise qisys.error.Error("%s does not exist" % pml_path)
         self.pml_path = pml_path
         self.base_dir = os.path.dirname(self.pml_path)
         self.manifest_xml = os.path.join(self.base_dir, "manifest.xml")
         if not os.path.exists(self.manifest_xml):
-            raise Exception("%s does not exist" % self.manifest_xml)
+            raise qisys.error.Error("%s does not exist" % self.manifest_xml)
         self.pkg_name = pkg_name(self.manifest_xml)
 
 
@@ -90,7 +91,8 @@ class PMLBuilder(object):
 Error when parsing {pml_path}
 {mess}
 """
-            raise Exception(mess.format(pml_path=pml_path, mess=str(e)))
+            raise qisys.error.Error(
+                    mess.format(pml_path=pml_path, mess=str(e)))
 
     def _load_pml(self, pml_path):
         for builder in self.builders:
@@ -99,7 +101,8 @@ Error when parsing {pml_path}
         root = tree.getroot()
         qibuild_elems = root.findall("qibuild")
         if qibuild_elems and not self.worktree:
-            raise Exception("<qibuild> tag found but not in a worktree")
+            raise qisys.error.Error(
+                    "<qibuild> tag found but not in a worktree")
         for qibuild_elem in qibuild_elems:
             name = qisys.qixml.parse_required_attr(qibuild_elem, "name", pml_path)
             project = self.build_worktree.get_build_project(name, raises=True)
@@ -108,7 +111,8 @@ Error when parsing {pml_path}
 
         qipython_elems = root.findall("qipython")
         if qipython_elems and not self.worktree:
-            raise Exception("<qipython> tag found but not in a worktree")
+            raise qisys.error.Error(
+                    "<qipython> tag found but not in a worktree")
         for qipython_elem in qipython_elems:
             name = qisys.qixml.parse_required_attr(qipython_elem, "name", pml_path)
             project = self.python_worktree.get_python_project(name, raises=True)
@@ -116,7 +120,8 @@ Error when parsing {pml_path}
 
         qilinguist_elems = root.findall("qilinguist")
         if qilinguist_elems and not self.worktree:
-            raise Exception("<qilinguist> tag found but not in a worktree")
+            raise qisys.error.Error(
+                    "<qilinguist> tag found but not in a worktree")
         for qilinguist_elem in qilinguist_elems:
             name = qisys.qixml.parse_required_attr(qilinguist_elem, "name", pml_path)
             project = self.linguist_worktree.get_linguist_project(name, raises=True)
@@ -160,7 +165,7 @@ Error when parsing {pml_path}
             mess = "Some files do not exist\n"
             for error in errors:
                 mess += error + "\n"
-            raise Exception(mess)
+            raise qisys.error.Error(mess)
 
     def configure(self):
         """ Configure every project """
@@ -224,7 +229,8 @@ Error when parsing {pml_path}
 
         # If the package is not valid, do not go further
         if not self.validator.is_valid and not force:
-            raise Exception("Given package does not satisfy "
+            raise qisys.error.Error(
+                            "Given package does not satisfy "
                             "default package requirements.\n"
                             "Use option '--force' to bypass this validation")
 

--- a/python/qipkg/metapackage.py
+++ b/python/qipkg/metapackage.py
@@ -5,6 +5,7 @@ import os
 import zipfile
 
 from qisys import ui
+import qisys.error
 import qisys.qixml
 
 class MetaPackage(object):
@@ -23,7 +24,7 @@ class MetaPackage(object):
         tree = qisys.qixml.read(self.mpml)
         root = tree.getroot()
         if root.tag != "metapackage":
-            raise Exception("""
+            raise qisys.error.Error("""
 Invalid mpml %s
 Root element must be <metapackage>
 """ % self.mpml)

--- a/python/qipkg/test/test_qipkg.py
+++ b/python/qipkg/test/test_qipkg.py
@@ -5,6 +5,7 @@ import os
 import sys
 
 import qisys.command
+import qisys.error
 import qisys.qixml
 from qisys.qixml import etree
 import qipkg.builder
@@ -146,7 +147,7 @@ def test_no_worktre_bad_pml(tmpdir, monkeypatch):
 """)
     monkeypatch.chdir(tmpdir)
     # pylint:disable-msg=E1101
-    with pytest.raises(Exception) as error:
+    with pytest.raises(qisys.error.Error) as error:
         package = qisys.script.run_action("qipkg.actions.make_package", [pml_path.strpath])
     assert "not in a worktree" in error.value.message
 
@@ -269,7 +270,9 @@ def test_deploy_package_from_pml(qipkg_action, tmpdir):
     pml_path = os.path.join(d_proj.path, "d_pkg.pml")
     url = get_ssh_url(tmpdir)
 
-    qipkg_action("deploy-package", pml_path, "--url", url)
+    # this will call sys.exit because 'import qi' will fail,
+    # but the package will still get deployed
+    qipkg_action("deploy-package", pml_path, "--url", url, retcode=True)
 
     expected_path = os.path.expanduser("~/d-0.1.pkg")
     assert os.path.exists(expected_path)

--- a/python/qipy/actions/run.py
+++ b/python/qipy/actions/run.py
@@ -37,7 +37,7 @@ def do(args):
     if not os.path.exists(venv_root):
         err = "No Virtualenv found in %s\n" % (venv_root)
         err += "Please run `qipy bootstrap`"
-        raise Exception(err)
+        ui.fatal(err)
 
     binaries_path = virtualenv.path_locations(venv_root)[-1]
 

--- a/python/qipy/parsers.py
+++ b/python/qipy/parsers.py
@@ -1,6 +1,8 @@
 ## Copyright (c) 2012-2016 Aldebaran Robotics. All rights reserved.
 ## Use of this source code is governed by a BSD-style license that can be
 ## found in the COPYING file.
+
+import qisys.error
 import qisys.parsers
 import qibuild.parsers
 import qipy.worktree
@@ -23,7 +25,7 @@ def get_one_python_project(python_worktree, args):
     parser = PythonProjectParser(python_worktree)
     projects = parser.parse_args(args)
     if not len(projects) == 1:
-        raise Exception("This action can only work with one project")
+        raise qisys.error.Error("This action can only work with one project")
     return projects[0]
 
 def get_python_builder(args, verbose=True):
@@ -69,11 +71,10 @@ class PythonProjectParser(qisys.parsers.AbstractProjectParser):
         project = self.python_worktree.get_python_project(project_arg, raises=True)
         return [project]
 
-class CouldNotGuessProjectName(Exception):
+class CouldNotGuessProjectName(qisys.error.Error):
     def __str__(self):
         return """
 Could not guess python project name from current working directory
 Please go inside a python project, or specify the project name
 on the command line
 """
-

--- a/python/qipy/project.py
+++ b/python/qipy/project.py
@@ -3,6 +3,7 @@
 ## found in the COPYING file.
 import os
 
+import qisys.error
 import qisys.sh
 
 class PythonProject(object):
@@ -43,13 +44,13 @@ Either write a setup.py file and use
 Or specify at least some scripts, modules or packages
 in the qiproject.xml file
 """
-            raise Exception(mess)
+            raise qisys.error.Error(mess)
         if self.setup_with_distutils:
             python = self.worktree.python
             if not os.path.exists(python):
                 mess = "Python executable not found in virtualenv\n"
                 mess += "Try running `qipy bootstrap`"
-                raise Exception(mess)
+                raise qisys.error.Error(mess)
             cmd = [python, "setup.py", "install", "--root", dest, "--prefix=."]
             qisys.command.call(cmd, cwd=self.path)
             return

--- a/python/qipy/worktree.py
+++ b/python/qipy/worktree.py
@@ -6,6 +6,7 @@ import difflib
 import virtualenv
 
 from qisys import ui
+import qisys.error
 import qisys.worktree
 import qisys.qixml
 
@@ -43,7 +44,7 @@ Found two projects with the same name. (%s)
 %s
 %s
 """ % (new_project.name, seen_names[new_project.name], new_project.src)
-                raise Exception(mess)
+                raise qisys.error.Error(mess)
             self.python_projects.append(new_project)
             seen_names[new_project.name] = new_project.src
 

--- a/python/qisrc/actions/add.py
+++ b/python/qisrc/actions/add.py
@@ -6,6 +6,7 @@
 
 import os
 
+from qisys import ui
 import qisys
 import qisys.parsers
 import qisrc.git
@@ -41,6 +42,6 @@ def do(args):
     worktree_proj = worktree.get_project(src)
     proj_path = worktree_proj.path
     if os.path.exists(proj_path):
-        raise Exception("%s already exists" % proj_path)
+        ui.fatal("%s already exists" % proj_path)
     git = qisrc.git.Git(proj_path)
     git.clone(url, "--branch", args.branch)

--- a/python/qisrc/actions/create.py
+++ b/python/qisrc/actions/create.py
@@ -36,7 +36,7 @@ def do(args):
         output_dir = os.path.join(os.getcwd(), output_dir)
 
     if os.path.exists(output_dir):
-        raise Exception("%s already exists" % output_dir)
+        raise ui.fatal("%s already exists" % output_dir)
 
     template_path = args.template_path
     if not template_path:

--- a/python/qisrc/actions/maintainers.py
+++ b/python/qisrc/actions/maintainers.py
@@ -39,7 +39,7 @@ def do(args):
     projects = qisys.parsers.get_projects(worktree, args)
 
     if not projects:
-        raise Exception("Please specify at least one project")
+        ui.fatal("Please specify at least one project")
 
     if args.maintainers_action == "add":
         to_call = add_maintainer

--- a/python/qisrc/actions/reset.py
+++ b/python/qisrc/actions/reset.py
@@ -103,7 +103,7 @@ def reset_manifest(git_worktree, snapshot, ignore_groups=False):
     else:
         groups = manifest.groups
     if not manifest.branch:
-        raise Exception("No branch configured for the manifest of the snapshot")
+        ui.fatal("No branch configured for the manifest of the snapshot")
     ok = git_worktree.configure_manifest(manifest.url, groups=groups,
                                          branch=manifest.branch, ref=manifest.ref)
     if not ok:

--- a/python/qisrc/git.py
+++ b/python/qisrc/git.py
@@ -14,8 +14,8 @@ import subprocess
 import functools
 
 from qisys import ui
-import qisys
 import qisys.command
+import qisys.sh
 
 class Git(object):
     """ The Git represent a git tree """
@@ -182,7 +182,7 @@ class Git(object):
             mess  = "Broken submodules configuration detected for %s\n" % self.repo
             mess += "git status returned %s\n" % out
             if raises:
-                raise Exception(mess)
+                raise qisys.error.Error(mess)
             else:
                 return mess
         if not out:
@@ -194,7 +194,7 @@ class Git(object):
         mess  = "Failed to update submodules\n"
         mess += out
         if raises:
-            raise Exception(mess)
+            raise qisys.error.Error(mess)
         return mess
 
     def get_local_branches(self):
@@ -206,7 +206,7 @@ class Git(object):
         if status != 0:
             mess  = "Could not get the list of local branches\n"
             mess += "Error was: %s" % out
-            raise Exception(mess)
+            raise qisys.error.Error(mess)
         lines = out.splitlines()
         # Remove the star and the indentation:
         return [x[2:] for x in lines]

--- a/python/qisrc/git_config.py
+++ b/python/qisrc/git_config.py
@@ -11,6 +11,7 @@ Delegates most of the work to :py:mod:`qisrc.git`` and
 import re
 import os
 
+import qisys.error
 import qisys.qixml
 import qisrc.git
 import qisrc.review
@@ -79,7 +80,7 @@ class Remote(object):
                 username = qisrc.review.get_gerrit_username(self.server,
                                                             ssh_port=self.port)
                 if not username:
-                    raise Exception("Could not guess ssh username")
+                    raise qisys.error.Error("Could not guess ssh username")
                 self.username = username
             prefix =  "ssh://%s@%s" % (username, self.server)
             if self.port:
@@ -122,7 +123,8 @@ class Remote(object):
             self.prefix = prefix
 
         if not self.prefix:
-            raise Exception("Could not parse %s as a git url" % self.url)
+            raise qisys.error.Error(
+                    "Could not parse %s as a git url" % self.url)
 
 
     def __repr__(self):

--- a/python/qisrc/groups.py
+++ b/python/qisrc/groups.py
@@ -5,6 +5,7 @@ import os
 
 import xml.etree.ElementTree as etree
 
+import qisys.error
 import qisys.qixml
 
 from qisys import ui
@@ -116,5 +117,5 @@ def get_groups(worktree):
     return groups
 
 
-class GroupError(Exception):
+class GroupError(qisys.error.Error):
     pass

--- a/python/qisrc/manifest.py
+++ b/python/qisrc/manifest.py
@@ -11,12 +11,13 @@ import functools
 import StringIO
 
 from qisys import ui
+import qisys.error
 import qisys.sh
 import qisys.qixml
 import qisrc.git_config
 import qisrc.groups
 
-class ManifestError(Exception):
+class ManifestError(qisys.error.Error):
     pass
 
 
@@ -201,7 +202,7 @@ No such project: {1}
         """ Remove a repo from the manifest """
         matching_repo = self.get_repo(project_name)
         if not matching_repo:
-            raise Exception("No such repo:", project_name)
+            raise qisys.error.Error("No such repo:", project_name)
         self.repos.remove(matching_repo)
 
     @change_config

--- a/python/qisrc/parsers.py
+++ b/python/qisrc/parsers.py
@@ -8,6 +8,7 @@ import os
 
 from collections import OrderedDict
 
+import qisys.error
 import qisys.parsers
 import qisys.worktree
 import qisrc.worktree
@@ -61,7 +62,7 @@ def get_one_git_project(git_worktree, args):
     parser = GitProjectParser(git_worktree)
     projects = parser.parse_args(args)
     if not len(projects) == 1:
-        raise Exception("This action can only work with one project")
+        raise qisys.error.Error("This action can only work with one project")
     return projects[0]
 
 

--- a/python/qisrc/rebase.py
+++ b/python/qisrc/rebase.py
@@ -1,7 +1,9 @@
 ## Copyright (c) 2012-2016 Aldebaran Robotics. All rights reserved.
 ## Use of this source code is governed by a BSD-style license that can be
 ## found in the COPYING file.
+
 from qisys import ui
+import qisys.error
 import qisys.interact
 
 import qisrc.manifest
@@ -17,7 +19,7 @@ def rebase_worktree(git_worktree, git_projects, branch=None,
         for git_project in errors:
             mess += " * " + git_project.src
             mess += "\n"
-        raise Exception(mess)
+        raise qisys.error.Error(mess)
 
     if push:
         push_projects(rebased_projects, dry_run=dry_run)

--- a/python/qisrc/snapshot.py
+++ b/python/qisrc/snapshot.py
@@ -9,6 +9,7 @@ import json
 
 from qisys import ui
 
+import qisys.error
 import qisrc.git
 import qisrc.status
 import qisrc.reset
@@ -86,7 +87,8 @@ class Snapshot(object):
         elif self.format_version == 2:
             manifest_json = parsed_json["manifest"]
         else:
-            raise Exception("unknown format: %s" % self.format_version)
+            raise qisys.error.Error(
+                    "unknown format: %s" % self.format_version)
         self.refs = parsed_json["refs"]
         for key, value in manifest_json.iteritems():
             setattr(self.manifest, key, value)

--- a/python/qisrc/sync.py
+++ b/python/qisrc/sync.py
@@ -10,6 +10,7 @@ import os
 
 from qisys.qixml import etree
 from qisys import ui
+import qisys.error
 import qisys.qixml
 import qisrc.git
 import qisrc.manifest
@@ -238,7 +239,7 @@ class WorkTreeSyncer(object):
 No manifest set for worktree in {root}
 Please run `qisrc init MANIFEST_URL`
 """
-            raise Exception(mess.format(root=self.git_worktree.root))
+            raise qisys.error.Error(mess.format(root=self.git_worktree.root))
         git = qisrc.git.Git(self.manifest_repo)
         git.set_remote("origin", self.manifest.url)
         if git.get_current_branch() != self.manifest.branch:
@@ -251,7 +252,7 @@ Please run `qisrc init MANIFEST_URL`
             else:
                 git.reset("--hard", "origin/%s" % self.manifest.branch)
         if not transaction.ok:
-            raise Exception("Update failed\n" + transaction.output)
+            raise qisys.error.Error("Update failed\n" + transaction.output)
 
     def _sync_repos(self, old_repos, new_repos, force=False,
                     worktree_clone=None):

--- a/python/qisrc/templates.py
+++ b/python/qisrc/templates.py
@@ -4,17 +4,18 @@
 import os
 
 from qisys import ui
+import qisys.error
 import qisys.sh
 
 
 def process(input_dir, output_dir, **kwargs):
     if not os.path.isdir(input_dir):
         if os.path.exists(input_dir):
-            raise Exception("%s is not a directory" % input_dir)
+            raise qisys.error.Error("%s is not a directory" % input_dir)
         else:
-            raise Exception("%s does not exist" % input_dir)
+            raise qisys.error.Error("%s does not exist" % input_dir)
     if qisys.sh.is_path_inside(output_dir, input_dir):
-        raise Exception("output directory is inside input directory")
+        raise qisys.error.Error("output directory is inside input directory")
     ui.info(ui.green, "Generating code in", output_dir)
     for filename in qisys.sh.ls_r(input_dir):
         output_name = process_string(filename, **kwargs)

--- a/python/qisrc/test/fake_git.py
+++ b/python/qisrc/test/fake_git.py
@@ -4,6 +4,7 @@
 
 import pytest
 
+import qisys.error
 import qisrc.git
 from qisrc.test.conftest import FakeGit
 
@@ -32,7 +33,7 @@ def test_wrong_setup():
     git.add_result("checkout", 0, "")
     git.checkout("-f", "master")
     # pylint: disable-msg=E1101
-    with pytest.raises(Exception) as e:
+    with pytest.raises(qisys.error.Error) as e:
         git.fetch()
     assert "Unexpected call to fetch" in e.value.message
 
@@ -42,7 +43,7 @@ def test_configured_but_not_called_enough():
     git.add_result("checkout", 1, "Unstaged changes")
     git.checkout("next")
     # pylint: disable-msg=E1101
-    with pytest.raises(Exception) as e:
+    with pytest.raises(qisys.error.Error) as e:
         git.check()
     assert "checkout was configured to be called 2 times" in e.value.message
     assert "was only called 1 times" in e.value.message

--- a/python/qisrc/test/test_qisrc_add.py
+++ b/python/qisrc/test/test_qisrc_add.py
@@ -27,8 +27,9 @@ def test_qisrc_add_url_in_subdir(qisrc_action, git_server):
     git_worktree = qisrc_action.git_worktree
     assert git_worktree.get_git_project("lib/foo")
 
-def test_qisrc_add_already_exists(qisrc_action, git_server):
+def test_qisrc_add_already_exists(qisrc_action, git_server, record_messages):
     foo = git_server.create_repo("foo.git")
     qisrc_action.tmpdir.mkdir("foo")
-    error = qisrc_action("add", foo.clone_url, raises=True)
-    assert "already exists" in error
+    rc = qisrc_action("add", foo.clone_url, retcode=True)
+    assert rc != 0
+    assert record_messages.find("already exists")

--- a/python/qisrc/test/test_qisrc_create.py
+++ b/python/qisrc/test/test_qisrc_create.py
@@ -64,7 +64,7 @@ def test_create_inside_template(qisrc_action, tmpdir):
     inside = tmpl.mkdir("dest")
     with qisys.sh.change_cwd(inside.strpath):
         # pylint:disable-msg=E1101
-        with pytest.raises(Exception) as e:
+        with pytest.raises(qisys.error.Error) as e:
             qisys.script.run_action("qisrc.actions.create",
                                     ["--template-path", tmpl.strpath, "HelloWorld"])
         assert e.value.message == "output directory is inside input directory"

--- a/python/qisrc/test/test_qisrc_init.py
+++ b/python/qisrc/test/test_qisrc_init.py
@@ -2,6 +2,7 @@
 ## Use of this source code is governed by a BSD-style license that can be
 ## found in the COPYING file.
 
+import qisys.error
 import qisys.script
 import qisrc.git
 
@@ -153,7 +154,7 @@ def test_manifest_branch_does_not_exist(qisrc_action, git_server):
     git_server.create_repo("bar.git")
     manifest_url = git_server.manifest_url
     # pylint:disable-msg=E1101
-    with pytest.raises(Exception) as e:
+    with pytest.raises(qisys.error.Error) as e:
         qisrc_action("init", git_server.manifest_url, "--branch", "devel")
     assert "origin/devel" in e.value.message
 

--- a/python/qisrc/test/test_qisrc_maintainers.py
+++ b/python/qisrc/test/test_qisrc_maintainers.py
@@ -9,9 +9,10 @@
 ## found in the COPYING file.
 import qisrc.maintainers
 
-def test_no_project(qisrc_action):
-    error = qisrc_action("maintainers", "--list", raises=True)
-    assert "at least one project" in error
+def test_no_project(qisrc_action, record_messages):
+    rc = qisrc_action("maintainers", "--list", retcode=True)
+    assert rc != 0
+    assert record_messages.find("at least one project")
 
 def test_no_maintainers_yet(qisrc_action, record_messages):
     foo = qisrc_action.worktree.create_project("foo")

--- a/python/qisrc/test/test_qisrc_rebase.py
+++ b/python/qisrc/test/test_qisrc_rebase.py
@@ -3,6 +3,7 @@
 ## found in the COPYING file.
 import pytest
 
+import qisys.error
 from qisrc.test.conftest import TestGitWorkTree
 from qisrc.test.conftest import TestGit
 
@@ -36,7 +37,7 @@ def test_rebase_conflict(git_server, qisrc_action):
     _, before = git.call("show", raises=False)
     git.fetch()
     # pylint: disable-msg=E1101
-    with pytest.raises(Exception) as e:
+    with pytest.raises(qisys.error.Error) as e:
         qisrc_action("rebase", "--branch", "master", "--all")
     assert " * foo" in e.value.message
     _, after = git.call("show", raises=False)

--- a/python/qisrc/worktree.py
+++ b/python/qisrc/worktree.py
@@ -6,13 +6,14 @@ import copy
 import operator
 
 from qisys import ui
+import qisys.error
 import qisys.worktree
 import qisrc.git
 import qisrc.snapshot
 import qisrc.sync
 import qisrc.project
 
-class NotInAGitRepo(Exception):
+class NotInAGitRepo(qisys.error.Error):
     """ Custom exception when user did not
     specify any git repo ond the command line
     and we did not manage to guess one from the
@@ -329,7 +330,7 @@ class GitWorkTree(qisys.worktree.WorkTreeObserver):
         ref = "origin/" + branch
         manifest = qisrc.manifest.from_git_repo(self._syncer.manifest_repo, ref)
         if not manifest:
-            raise Exception("Could not read manifest on %s"% ref)
+            raise qisys.error.Error("Could not read manifest on %s"% ref)
         groups = self._syncer.manifest.groups
         repos = manifest.get_repos(groups=groups)
         for repo in repos:
@@ -394,5 +395,5 @@ Tips:
 """
     ui.warning(mess.format(worktree=worktree, groups=groups) + tips)
 
-class NoSuchGitProject(Exception):
+class NoSuchGitProject(qisys.error.Error):
     pass

--- a/python/qisys/archive.py
+++ b/python/qisys/archive.py
@@ -35,6 +35,7 @@ import operator
 import subprocess
 import zipfile
 
+import qisys.error
 import qisys.sh
 import qisys.command
 from qisys import ui
@@ -42,11 +43,10 @@ from qisys import ui
 
 KNOWN_ALGOS = ["zip", "tar", "gzip", "bzip2", "xz"]
 
-class InvalidArchive(Exception):
+class InvalidArchive(qisys.error.Error):
     """Just a custom exception """
     def __init__(self, message):
         self._message = message
-        Exception.__init__(self)
 
     def __str__(self):
         return self._message
@@ -62,7 +62,7 @@ def _check_algo(algo):
     mess += "Known algorithms are: \n"
     for algorithm in KNOWN_ALGOS:
         mess += " * " + algorithm + "\n"
-    raise Exception(mess)
+    raise qisys.error.Error(mess)
 
 # Symlink support in zip archive (for both compression and extraction) widely
 # inspired from:
@@ -154,7 +154,7 @@ Please set only one of these two options to 'True'
     except zipfile.BadZipfile:
         mess = 'ZIP file seems corrupted. Try removing it and relaunch command.\n'
         mess += '              rm ' + archive + '\n'
-        raise Exception(mess)
+        raise qisys.error.Error(mess)
     members  = archive_.infolist()
     # There is always the top dir as the first element of the archive
     # (or so we hope)
@@ -291,7 +291,7 @@ Please set only one of these two options to 'True'
         mess += "(algo: %s)\n" % algo
         mess += "Calling tar failed\n"
         mess += str(err)
-        raise Exception(mess)
+        raise qisys.error.Error(mess)
     return output
 
 
@@ -354,7 +354,7 @@ Please set only one of these two options to 'True'
         mess  = "Could not extract %s to %s\n" % (archive, directory)
         mess += "Calling tar failed\n"
         mess += str(err)
-        raise Exception(mess)
+        raise qisys.error.Error(mess)
     if not quiet:
         for line in str(printed).split("\n"):
             if not output_filter or not re.search(output_filter, line):

--- a/python/qisys/command.py
+++ b/python/qisys/command.py
@@ -15,7 +15,7 @@ import threading
 import Queue
 
 from qisys import ui
-import qisys
+import qisys.error
 import qisys.envsetter
 
 # Cache for find_program()
@@ -166,7 +166,7 @@ def str_from_signal(code):
         return "Aborted"
     return "%i" % code
 
-class CommandFailedException(Exception):
+class CommandFailedException(qisys.error.Error):
     """Custom exception """
     def __init__(self, cmd, returncode, cwd=None, stdout=None, stderr=None):
         self.cmd = cmd
@@ -197,7 +197,7 @@ Working dir was {cwd}
             mess  = "\n".join("    " + line for line in self.stderr.split("\n"))
         return mess
 
-class ProcessCrashedError(Exception):
+class ProcessCrashedError(qisys.error.Error):
     """An other custom exception, used by call_background """
     def __init__(self, cmd):
         self.cmd = cmd
@@ -207,7 +207,7 @@ class ProcessCrashedError(Exception):
         mess += "Full command: %s" % self.cmd
         return mess
 
-class NotInPath(Exception):
+class NotInPath(qisys.error.Error):
     """Custom exception """
     def __init__(self, executable, env=None):
         self.executable = executable
@@ -410,7 +410,7 @@ def call(cmd, cwd=None, env=None, ignore_ret_code=False, quiet=False):
         if not os.path.exists(cwd):
             # We know we are likely to have a problem on windows here,
             # so always raise.
-            raise Exception("Trying to to run %s in non-existing %s" %
+            raise qisys.error.Error("Trying to to run %s in non-existing %s" %
                 (" ".join(cmd), cwd))
 
     ui.debug("Calling:", " ".join(cmd))

--- a/python/qisys/command.py
+++ b/python/qisys/command.py
@@ -159,11 +159,18 @@ def str_from_signal(code):
     if os.name == "nt":
         # windows ret code are usually displayed
         # in hexa:
-        return "0x%X" % (2 ** 32 - code)
+        value = 2 ** 32 - code
+        as_str = "0x%X" % (value)
+        if value == 0xC0000135:
+            return "%s : Failed to find required DLL" % as_str
+        else:
+            return as_str
     if code == signal.SIGSEGV:
         return "Segmentation fault"
     if code == signal.SIGABRT:
         return "Aborted"
+    if code == signal.SIGTRAP and sys.platform == "darwin":
+        return "Trace trap (could not find .dylib)"
     return "%i" % code
 
 class CommandFailedException(qisys.error.Error):

--- a/python/qisys/envsetter.py
+++ b/python/qisys/envsetter.py
@@ -11,7 +11,7 @@ import os
 import sys
 import subprocess
 
-import qisys
+import qisys.error
 import qisys.sh
 
 class EnvSetter(object):
@@ -110,7 +110,8 @@ class EnvSetter(object):
         # TODO: handle non asccii chars?
         # Hint: decode("mcbs") ...
         if not os.path.exists(bat_file):
-            raise Exception("general.env.bat_file (%s) does not exist" % bat_file)
+            raise qisys.error.Error(
+                    "bat file (%s) does not exist" % bat_file)
 
         # set of environment variables that are in fact list of paths
         # FIXME: what should we do with other env?
@@ -125,7 +126,7 @@ class EnvSetter(object):
         if process.returncode != 0:
             mess  = "Calling %s failed\n" % bat_file
             mess += "Error was: %s" % err
-            raise Exception(mess)
+            raise qisys.error.Error(mess)
 
         #pylint: disable-msg=E1103
         for line in out.split("\n"):

--- a/python/qisys/error.py
+++ b/python/qisys/error.py
@@ -1,0 +1,20 @@
+""" Handling exception inside qBuild"""
+
+class Error(Exception):
+    """ Base class for all qibuild exceptions.
+
+    When an exception is raised that is not a daughter
+    of this class, assume it's a crash and generate a
+    bug report
+
+    Alternatively, if you are in an action,
+    you can use:
+
+        ui.fatal("message")
+
+    or simply:
+
+        sys.exit(2)
+
+    """
+    pass

--- a/python/qisys/parsers.py
+++ b/python/qisys/parsers.py
@@ -9,6 +9,7 @@ import argparse
 import multiprocessing
 import os
 
+import qisys.error
 import qisys.sh
 import qisys.worktree
 
@@ -136,9 +137,9 @@ def get_one_project(worktree, args):
     parser = WorkTreeProjectParser(worktree)
     projects = parser.parse_args(args)
     if projects is None:
-        raise Exception("No project found")
+        raise qisys.error.Error("No project found")
     if not len(projects) == 1:
-        raise Exception("This action can only work with one project")
+        raise qisys.error.Error("This action can only work with one project")
     return projects[0]
 
 ##
@@ -174,7 +175,7 @@ class AbstractProjectParser(object):
         if not hasattr(args, "single"):
             args.single = False
         if args.all and args.single:
-            raise Exception("Cannot use --single with --all")
+            raise qisys.error.Error("Cannot use --single with --all")
         # pylint: disable-msg=E1103
         if args.all:
             return self.all_projects(args)

--- a/python/qisys/qixml.py
+++ b/python/qisys/qixml.py
@@ -9,6 +9,8 @@
 """
 
 import re
+
+import qisys.error
 from qisys import ui
 
 from xml.etree import ElementTree as etree
@@ -46,7 +48,7 @@ def raise_parse_error(message, xml_path=None, tree=None):
         as_str = etree.tostring(tree)
         mess += "Could not parse:\t%s\n" % as_str
     mess += message
-    raise Exception(mess)
+    raise qisys.error.Error(mess)
 
 def parse_bool_attr(tree, name, default=False):
     """ Parse a boolean attribute of an element
@@ -243,7 +245,7 @@ class XMLParser(object):
         if value is None:
             mess = "Node '%s' must have a '%s' attribute" % (node_name,
                                                                attribute_name)
-            raise Exception(mess)
+            raise qisys.error.Error(mess)
 
     def xml_elem(self, node_name=None):
         """ Get the xml representation of the target
@@ -327,7 +329,7 @@ def _get_value_for_type(type_value, value):
         if value.lower() in ["false", "0"]:
             return False
         mess = "Waiting for a boolean but value is '%s'." % value
-        raise Exception(mess)
+        raise qisys.error.Error(mess)
     if type_value == list:
         return value.split(" ")
     return value

--- a/python/qisys/remote.py
+++ b/python/qisys/remote.py
@@ -16,6 +16,7 @@ import urllib2
 import StringIO
 
 from qisys import ui
+import qisys.error
 import qisys.command
 import qisys.sh
 
@@ -144,7 +145,7 @@ def download(url, output_dir, output_name=None,
     except Exception, e:
         mess  = "Could not save %s to %s\n" % (url, dest_name)
         mess += "Error was %s" % e
-        raise Exception(mess)
+        raise qisys.error.Error(mess)
 
     url_split = urlparse.urlsplit(url)
     url_obj = None
@@ -200,7 +201,7 @@ def download(url, output_dir, output_name=None,
             url_obj.close()
     if error:
         qisys.sh.rm(dest_name)
-        raise Exception(error)
+        raise qisys.error.Error(error)
 
     return dest_name
 
@@ -209,7 +210,7 @@ def deploy(local_directory, remote_url, filelist=None):
     # ensure destination directory exist before deploying data
     if not (remote_url.host and remote_url.remote_directory):
         message = "Remote URL is invalid; host and remote directory must be specified"
-        raise Exception(message)
+        raise qisys.error.Error(message)
 
     user = "%s@" % remote_url.user if remote_url.user else ""
 
@@ -243,7 +244,7 @@ def deploy(local_directory, remote_url, filelist=None):
 
 
 
-class URLParseError(Exception):
+class URLParseError(qisys.error.Error):
     def __int__(self, message):
         super(URLParseError).__int__(message)
 

--- a/python/qisys/sh.py
+++ b/python/qisys/sh.py
@@ -19,6 +19,7 @@ import subprocess
 import ntpath
 import posixpath
 
+import qisys.error
 from qisys import ui
 
 try:
@@ -157,7 +158,7 @@ def configure_file(in_path, out_path, copy_only=False, *args, **kwargs):
 
 def _copy_link(src, dest, quiet):
     if not os.path.islink(src):
-        raise Exception("%s is not a link!" % src)
+        raise qisys.error.Error("%s is not a link!" % src)
 
     target = os.readlink(src)
         #remove existing stuff
@@ -193,7 +194,8 @@ def _handle_dirs(src, dest, root, directories, filter_fun, quiet):
             installed.append(directory)
         else:
             if os.path.lexists(ddest) and not os.path.isdir(ddest):
-                raise Exception("Expecting a directory but found a file: %s" % ddest)
+                raise qisys.error.Error(
+                        "Expecting a directory but found a file: %s" % ddest)
             mkdir(ddest, recursive=True)
     return installed
 
@@ -220,7 +222,8 @@ def _handle_files(src, dest, root, files, filter_fun, quiet):
             installed.append(rel_path)
         else:
             if os.path.lexists(fdest) and os.path.isdir(fdest):
-                raise Exception("Expecting a file but found a directory: %s" % fdest)
+                raise qisys.error.Error(
+                        "Expecting a file but found a directory: %s" % fdest)
             if not quiet:
                 print "-- Installing %s" % fdest
             mkdir(new_root, recursive=True)
@@ -259,7 +262,7 @@ def install(src, dest, filter_fun=None, quiet=False):
     if not os.path.exists(src):
         mess = "Could not install '%s' to '%s'\n" % (src, dest)
         mess += '%s does not exist' % src
-        raise Exception(mess)
+        raise qisys.error.Error(mess)
 
     src = to_native_path(src, normcase=False)
     dest = to_native_path(dest, normcase=False)
@@ -272,7 +275,8 @@ def install(src, dest, filter_fun=None, quiet=False):
 
     if os.path.isdir(src):
         if src == dest:
-            raise Exception("source and destination are the same directory")
+            raise qisys.error.Error(
+                    "source and destination are the same directory")
         for (root, dirs, files) in os.walk(src):
             dirs = _handle_dirs (src, dest, root, dirs,  filter_fun, quiet)
             files = _handle_files(src, dest, root, files, filter_fun, quiet)
@@ -284,7 +288,8 @@ def install(src, dest, filter_fun=None, quiet=False):
         if os.path.isdir(dest):
             dest = os.path.join(dest, os.path.basename(src))
         if src == dest:
-            raise Exception("source and destination are the same file")
+            raise qisys.error.Error(
+                    "source and destination are the same file")
         mkdir(os.path.dirname(dest), recursive=True)
         if sys.stdout.isatty() and not quiet:
             print "-- Installing %s" % dest
@@ -386,7 +391,8 @@ def rmtree(path):
         return
 
     if os.path.islink(path) or not os.path.isdir(path):
-        raise Exception('Called rmtree(%s) in non-directory' % path)
+        raise qisys.error.Error(
+                "Called rmtree(%s) in non-directory" % path)
 
     if sys.platform == 'win32':
         # Some people don't have the APIs installed. In that case we'll do without.
@@ -634,7 +640,7 @@ def change_cwd(directory):
     if not os.path.exists(directory):
         mess = "Cannot change working dir to '%s'\n" % directory
         mess += "This path does not exist"
-        raise Exception(mess)
+        raise qisys.error.Error(mess)
     previous_cwd = os.getcwd()
     os.chdir(directory)
     yield

--- a/python/qisys/sort.py
+++ b/python/qisys/sort.py
@@ -6,12 +6,13 @@
 
 """
 
+import qisys.error
+
 __all__ = [ "DagError", "assert_dag", "topological_sort" ]
 
-class DagError(Exception):
+class DagError(qisys.error.Error):
     """ Dag Exception """
     def __init__(self, node, parent, result):
-        Exception.__init__(self)
         self.node   = node
         self.parent = parent
         self.result = result

--- a/python/qisys/test/conftest.py
+++ b/python/qisys/test/conftest.py
@@ -11,6 +11,7 @@ import pytest
 import mock
 
 from qisys import ui
+import qisys.error
 import qisys.sh
 import qisys.script
 import qisys.interact
@@ -169,7 +170,7 @@ class TestAction(object):
             self.chdir(cwd)
         if kwargs.get("raises"):
         # pylint: disable-msg=E1101
-            with pytest.raises(Exception) as error:
+            with pytest.raises(qisys.error.Error) as error:
                 qisys.script.run_action(module_name, args)
             return str(error.value)
         if kwargs.get("retcode"):

--- a/python/qisys/test/test_archive.py
+++ b/python/qisys/test/test_archive.py
@@ -14,6 +14,7 @@ import pytest
 
 import qisys
 
+import qisys.error
 from qisys.archive import compress
 from qisys.archive import extract
 from qisys.archive import guess_algo
@@ -78,7 +79,7 @@ def test_extract_invalid_empty(tmpdir):
     archive = srcdir.join("empty.tar.gz")
     archive.write("")
     # pylint: disable-msg=E1101
-    with pytest.raises(Exception) as e:
+    with pytest.raises(qisys.error.Error) as e:
         qisys.archive.extract(archive.strpath, destdir.strpath)
     assert "tar failed" in e.value.message
 

--- a/python/qisys/test/test_parser.py
+++ b/python/qisys/test/test_parser.py
@@ -1,6 +1,8 @@
 ## Copyright (c) 2012-2016 Aldebaran Robotics. All rights reserved.
 ## Use of this source code is governed by a BSD-style license that can be
 ## found in the COPYING file.
+
+import qisys.error
 import qisys.parsers
 import qisys.worktree
 
@@ -101,6 +103,6 @@ def test_using_dash_all_with_dash_single(worktree, args):
     args.all = True
     args.single = True
     # pylint:disable-msg=E1101
-    with pytest.raises(Exception) as e:
+    with pytest.raises(qisys.error.Error) as e:
         qisys.parsers.get_projects(worktree, args)
     assert "--single with --all" in e.value.message

--- a/python/qisys/test/test_qixml.py
+++ b/python/qisys/test/test_qixml.py
@@ -3,6 +3,7 @@
 ## found in the COPYING file.
 import pytest
 
+import qisys.error
 import qisys.qixml
 from xml.etree import ElementTree as etree
 
@@ -35,19 +36,19 @@ def test_qixml_parse_bool_attr():
     tree = etree.fromstring("<foo bar=\"blaaaah\" />")
 
     # pylint: disable-msg=E1101
-    with pytest.raises(Exception):
+    with pytest.raises(qisys.error.Error):
         qisys.qixml.parse_bool_attr(tree, "bar")
 
 def test_parse_int_attr():
     tree = etree.fromstring("<foo />")
     # pylint: disable-msg=E1101
-    with pytest.raises(Exception):
+    with pytest.raises(qisys.error.Error):
         qisys.qixml.parse_int_attr(tree, "bar", default=None)
 
     assert qisys.qixml.parse_int_attr(tree, "bar", default=2) == 2
 
     # pylint: disable-msg=E1101
-    with pytest.raises(Exception):
+    with pytest.raises(qisys.error.Error):
         qisys.qixml.parse_int_attr(tree, "bar")
 
     tree = etree.fromstring("<foo bar=\"2\" />")
@@ -57,7 +58,7 @@ def test_parse_int_attr():
 
     tree = etree.fromstring("<foo bar=\"false\" />")
     # pylint: disable-msg=E1101
-    with pytest.raises(Exception):
+    with pytest.raises(qisys.error.Error):
         qisys.qixml.parse_int_attr(tree, "bar")
 
 def test_parse_list_attr():
@@ -70,7 +71,7 @@ def test_parse_list_attr():
 def test_parse_required_attr():
     tree = etree.fromstring("<foo />")
     # pylint: disable-msg=E1101
-    with pytest.raises(Exception):
+    with pytest.raises(qisys.error.Error):
         qisys.qixml.parse_required_attr(tree, "bar")
 
     tree = etree.fromstring("<foo bar=\"foo\" />")
@@ -115,7 +116,7 @@ def test_required_attr():
     foo = Foo()
     foo_parser = FooParser(foo)
     # pylint: disable-msg=E1101
-    with pytest.raises(Exception) as e:
+    with pytest.raises(qisys.error.Error) as e:
         foo_parser.parse(tree)
     assert e.value.message == "Node 'foo' must have a 'bar' attribute"
 

--- a/python/qisys/test/test_sh.py
+++ b/python/qisys/test/test_sh.py
@@ -7,6 +7,7 @@ import stat
 import sys
 import pytest
 
+import qisys.error
 import qisys.sh
 from qisrc.test.conftest import TestGit
 
@@ -26,11 +27,11 @@ def test_install_on_self(tmpdir):
     a_file = tmpdir.join("a")
     a_file.write("")
     # pylint: disable-msg=E1101
-    with pytest.raises(Exception) as e:
+    with pytest.raises(qisys.error.Error) as e:
         qisys.sh.install(a_file.strpath, tmpdir.strpath)
     assert "are the same file" in e.value.message
     # pylint: disable-msg=E1101
-    with pytest.raises(Exception) as e:
+    with pytest.raises(qisys.error.Error) as e:
         qisys.sh.install(tmpdir.strpath, tmpdir.strpath)
     assert "are the same directory" in e.value.message
 

--- a/python/qisys/test/test_ui.py
+++ b/python/qisys/test/test_ui.py
@@ -5,7 +5,10 @@
 """ Just some tests for ui """
 
 import io
+
+import qisys.error
 import qisys.ui as ui
+
 
 import pytest
 
@@ -24,10 +27,10 @@ def main():
 
 def test_valid_filename():
     # pylint:disable-msg=E1101
-    with pytest.raises(Exception):
+    with pytest.raises(qisys.error.Error):
         ui.valid_filename("foo/bar")
     # pylint:disable-msg=E1101
-    with pytest.raises(Exception):
+    with pytest.raises(qisys.error.Error):
         ui.valid_filename("..")
     ui.valid_filename("foo")
 

--- a/python/qisys/test/test_worktree.py
+++ b/python/qisys/test/test_worktree.py
@@ -14,6 +14,7 @@ import py
 import pytest
 import mock
 
+import qisys.error
 import qisys.sh
 import qisys.worktree
 
@@ -50,7 +51,7 @@ def test_add_project_simple(worktree):
 def test_fails_when_root_does_not_exists(tmpdir):
     non_exitsting = tmpdir.join("doesnotexist")
     # pylint: disable-msg=E1101
-    with pytest.raises(Exception) as e:
+    with pytest.raises(qisys.error.Error) as e:
         qisys.worktree.WorkTree(non_exitsting.strpath)
     assert "does not exist" in str(e.value)
 

--- a/python/qisys/ui.py
+++ b/python/qisys/ui.py
@@ -16,6 +16,8 @@ import datetime
 import difflib
 import functools
 
+import qisys.error
+
 # Try using pyreadline so that we can
 # have colors on windows, too.
 _console = None
@@ -205,6 +207,11 @@ def _msg(*tokens, **kwargs):
     else:
         fp.write(stringres)
         fp.flush()
+
+def fatal(*tokens, **kwargs):
+    """ Print an error message and calls sys.exit """
+    error(*tokens, **kwargs)
+    sys.exit(1)
 
 def error(*tokens, **kwargs):
     """ Print an error message """
@@ -424,7 +431,7 @@ def valid_filename(value):
 
     """
     if value in [".", ".."]:
-        raise Exception("Invalid name: %s" % value)
+        raise qisys.error.Error("Invalid name: %s" % value)
 
     # this is for Windows, but it does not hurt on other platforms
     bad_chars = r'<>:"/\|?*'
@@ -434,5 +441,5 @@ def valid_filename(value):
             mess += "A valid name should not contain any "
             mess += "of the following chars:\n"
             mess += " ".join(bad_chars)
-            raise Exception(mess)
+            raise qisys.error.Error(mess)
     return value

--- a/python/qisys/worktree.py
+++ b/python/qisys/worktree.py
@@ -14,6 +14,7 @@ import posixpath
 import operator
 import difflib
 
+import qisys.error
 import qisys.project
 import qisys.command
 import qisys.sh
@@ -34,7 +35,7 @@ class WorkTree(object):
 
         """
         if not os.path.exists(root):
-            raise Exception(""" \
+            raise qisys.error.Error(""" \
 Could not open WorkTree in {0}.
 This path does not exist
 """.format(root))
@@ -322,10 +323,10 @@ class WorkTreeCache(object):
             srcs.append(qisys.qixml.parse_required_attr(project_elem, "src"))
         return srcs
 
-class WorkTreeError(Exception):
+class WorkTreeError(qisys.error.Error):
     """ Just a custom exception. """
 
-class NotInWorkTree(Exception):
+class NotInWorkTree(qisys.error.Error):
     """ Just a custom exception. """
     def __str__(self):
         return """ Could not guess worktree from current working directory
@@ -335,7 +336,7 @@ class NotInWorkTree(Exception):
      - create a new work tree with `qibuild init`
 """
 
-class NoSuchProject(Exception):
+class NoSuchProject(qisys.error.Error):
     def __init__(self, name, message):
         self.name = name
         self.message = message

--- a/python/qitest/collector.py
+++ b/python/qitest/collector.py
@@ -5,7 +5,8 @@
 import os
 import json
 import glob
-import qisrc
+
+import qisys.error
 import qisys.ui as ui
 import qisys.command
 import qipy.venv
@@ -24,7 +25,7 @@ class PythonTestCollector:
         else:
             self.pytest_path = qisys.command.find_program("py.test")
         if not self.pytest_path:
-            raise Exception("pytest path is empty")
+            raise qisys.error.Error("pytest path is empty")
 
 
     def get_list_of_pytest(self, rep):
@@ -81,4 +82,3 @@ class PythonTestCollector:
                 self.get_test_and_write(project)
             projects.append(src)
         ui.info(ui.yellow, "%i tests found" % (len(self.tests_path)), ui.reset)
-

--- a/python/qitest/conf.py
+++ b/python/qitest/conf.py
@@ -5,11 +5,13 @@ import argparse
 import os
 import json
 
+import qisys.error
+
 def add_test(output, **kwargs):
     if not "name" in kwargs:
-        raise Exception("Should provide a test name")
+        raise qisys.error.Error("Should provide a test name")
     if not "cmd" in kwargs:
-        raise Exception("Should provide a test cmd")
+        raise qisys.error.Error("Should provide a test cmd")
     tests = list()
     if os.path.exists(output):
         with open(output, "r") as fp:
@@ -21,7 +23,7 @@ def add_test(output, **kwargs):
     if matching_test:
         mess = "A test named '%s' already exists. (cmd=%s)" % (
             matching_test["name"], matching_test["cmd"])
-        raise Exception(mess)
+        raise qisys.error.Error(mess)
 
     tests.append(kwargs)
     with open(output, "w") as fp:

--- a/python/qitest/parsers.py
+++ b/python/qitest/parsers.py
@@ -9,6 +9,7 @@ import copy
 import os
 
 from qisys import ui
+import qisys.error
 import qisys.parsers
 import qibuild.parsers
 import qitest.project
@@ -148,12 +149,12 @@ def get_test_runners(args):
             res.append(test_runner)
 
     if args.coverage and not build_projects_runners:
-        raise Exception("""\
+        raise qisys.error.Error("""\
 --coverage can only be used from a qibuild CMake project
 """)
     elif args.coverage:
         return build_projects_runners
 
     if not res:
-        raise Exception("Nothing found to test")
+        raise qisys.error.Error("Nothing found to test")
     return res

--- a/python/qitest/result.py
+++ b/python/qitest/result.py
@@ -5,9 +5,26 @@
 class TestResult:
     """ Just a small class to store the results for a test
 
+    The ``error`` attribute is special. If set to True, it will
+    cause TestSuiteRunner.run() to raise instead of simply returning
+    False.
+
+    Example include:
+
+        * There was a Python exception in the threads spawned
+          by the TestQueue
+
+        * A dependency library was not found
+
+    In both cases, the problem is in the build system and not the test
+    itself, that' s why we have to raise
+
+    The ``message`` is a list that will be sent to ``ui.info``. This
+    allows test runners to have better control on console output
     """
     def __init__(self, test):
         self.test = test
         self.time = 0
         self.ok = False
         self.message = list()
+        self.error = False

--- a/python/qitest/runner.py
+++ b/python/qitest/runner.py
@@ -7,6 +7,7 @@ import os
 import json
 
 from qisys import ui
+import qisys.error
 import qitest.test_queue
 
 class TestSuiteRunner(object):
@@ -57,7 +58,11 @@ class TestSuiteRunner(object):
     @patterns.setter
     def patterns(self, value):
         if value:
-            [re.compile(x) for x in value] # just checking regexps are valid
+            try:
+                [re.compile(x) for x in value]
+            except Exception as e:
+                raise qisys.error.Error(str(e))
+
         self._patterns = value
 
     @property

--- a/python/qitest/runner.py
+++ b/python/qitest/runner.py
@@ -43,6 +43,12 @@ class TestSuiteRunner(object):
         """ Run all the tests.
         Return True if and only if the whole suite passed.
 
+        Note: you should check for the return value of run() and
+        not catch exceptions. Exceptions raised during run() indicate
+        something is wrong but not in the tests themselves.
+
+        See :py:class:`.TestResult` for more details
+
         """
         test_queue = qitest.test_queue.TestQueue(self.tests)
         test_queue.launcher = self.launcher
@@ -105,6 +111,7 @@ class TestSuiteRunner(object):
         with open(fail_json, "r") as fp:
             names = json.load(fp)
         return names
+
 class TestLauncher(object):
     """ Interface for a class able to launch a test. """
     __metaclass__ = abc.ABCMeta
@@ -119,7 +126,6 @@ class TestLauncher(object):
     def launch(self, test):
         """ Should return a :py:class:`.TestResult` """
         pass
-
 
 def match_patterns(patterns, name, default=True):
     if not patterns:

--- a/python/qitest/test/test_conf.py
+++ b/python/qitest/test/test_conf.py
@@ -1,6 +1,8 @@
 ## Copyright (c) 2012-2016 Aldebaran Robotics. All rights reserved.
 ## Use of this source code is governed by a BSD-style license that can be
 ## found in the COPYING file.
+
+import qisys.error
 import qitest.conf
 
 import pytest
@@ -28,16 +30,16 @@ def test_can_add_tests(tmpdir):
 def test_errors(tmpdir):
     qitest_json_path = tmpdir.join("qitest.json").strpath
     # pylint: disable-msg=E1101
-    with pytest.raises(Exception) as e:
+    with pytest.raises(qisys.error.Error) as e:
         qitest.conf.add_test(qitest_json_path, name="foo")
     assert "Should provide a test cmd" in e.value.message
     # pylint: disable-msg=E1101
-    with pytest.raises(Exception) as e:
+    with pytest.raises(qisys.error.Error) as e:
         qitest.conf.add_test(qitest_json_path, cmd="foo")
     assert "Should provide a test name" in e.value.message
     qitest.conf.add_test(qitest_json_path, name="foo", cmd=["/path/to/foo"])
     # pylint: disable-msg=E1101
-    with pytest.raises(Exception) as e:
+    with pytest.raises(qisys.error.Error) as e:
         qitest.conf.add_test(qitest_json_path, name="foo", cmd=["/path/to/bar"])
     assert "A test named 'foo' already exists" in e.value.message
 

--- a/python/qitest/test/test_parsers.py
+++ b/python/qitest/test/test_parsers.py
@@ -5,6 +5,7 @@ import os
 
 import pytest
 
+import qisys.error
 import qitest.parsers
 
 from qibuild.test.conftest import TestBuildWorkTree
@@ -101,7 +102,7 @@ def test_qitest_json_from_worktree(args, build_worktree, monkeypatch):
 
 def test_nothing_to_test(args, cd_to_tmpdir):
     # pylint:disable-msg=E1101
-    with pytest.raises(Exception) as e:
+    with pytest.raises(qisys.error.Error) as e:
         qitest.parsers.get_test_runners(args)
     assert e.value.message == "Nothing found to test"
 

--- a/python/qitest/test/test_queue.py
+++ b/python/qitest/test/test_queue.py
@@ -1,11 +1,16 @@
 ## Copyright (c) 2012-2016 Aldebaran Robotics. All rights reserved.
 ## Use of this source code is governed by a BSD-style license that can be
 ## found in the COPYING file.
-from qisys import ui
+
 import time
+
+from qisys import ui
+import qisys.error
 import qitest.test_queue
 import qitest.runner
 import qitest.result
+
+import pytest
 
 class DummyProject(object):
     def __init__(self, tmpdir):
@@ -67,8 +72,9 @@ def test_queue_sad(tmpdir):
     }
 
     test_queue.launcher = dummy_launcher
-    test_queue.run(num_jobs=3)
-    assert not test_queue.ok
+    # pylint:disable-msg=E1101
+    with pytest.raises(qisys.error.Error):
+        test_queue.run(num_jobs=3)
 
 
 def test_one_job(tmpdir):

--- a/python/qitest/test/test_runner.py
+++ b/python/qitest/test/test_runner.py
@@ -1,6 +1,8 @@
 ## Copyright (c) 2012-2016 Aldebaran Robotics. All rights reserved.
 ## Use of this source code is governed by a BSD-style license that can be
 ## found in the COPYING file.
+
+import qisys.error
 import qitest.project
 import qitest.runner
 
@@ -30,7 +32,7 @@ def test_match_patterns(tmpdir):
     assert test_runner.tests == [test_foo, test_bar, test_foo_bar]
 
     # pylint: disable-msg=E1101
-    with pytest.raises(Exception):
+    with pytest.raises(qisys.error.Error):
         test_runner.patterns = "foo("
 
     test_runner.patterns = list()

--- a/python/qitoolchain/__init__.py
+++ b/python/qitoolchain/__init__.py
@@ -2,11 +2,12 @@
 ## Use of this source code is governed by a BSD-style license that can be
 ## found in the COPYING file.
 
-
 """ qitoolchain: a package to handle set of precompiled
 packages
 
 """
+
+import qisys.error
 
 from qitoolchain.toolchain import Toolchain
 from qitoolchain.toolchain import get_tc_names
@@ -19,5 +20,5 @@ def get_toolchain(tc_name):
         mess += "Known toolchains are:\n"
         for name in tc_names:
             mess +=  "  * " + name + "\n"
-        raise Exception(mess)
+        raise qisys.error.Error(mess)
     return Toolchain(tc_name)

--- a/python/qitoolchain/actions/add_package.py
+++ b/python/qitoolchain/actions/add_package.py
@@ -41,7 +41,7 @@ def do(args):
     except KeyError:
         legacy = True
     if legacy and not args.name:
-        raise Exception("Must specify --name when using legacy format")
+        ui.fatal("Must specify --name when using legacy format")
     if args.name and not legacy:
         ui.warning("--name ignored when using modern format")
 

--- a/python/qitoolchain/actions/import_package.py
+++ b/python/qitoolchain/actions/import_package.py
@@ -9,6 +9,7 @@
 import os
 
 from qisys import ui
+import qisys.error
 import qisys.parsers
 import qitoolchain
 import qitoolchain.parsers

--- a/python/qitoolchain/actions/make_package.py
+++ b/python/qitoolchain/actions/make_package.py
@@ -23,11 +23,11 @@ def do(args):
     output = args.output or os.getcwd()
     package_xml = os.path.join(args.directory, "package.xml")
     if not os.path.exists(package_xml):
-        raise Exception("Expecting a package.xml at the root of the package")
+        ui.fatal("Expecting a package.xml at the root of the package")
     tree = qisys.qixml.read(package_xml)
     root = tree.getroot()
     if root.tag != "package":
-        raise Exception("Root element should have a 'package' tag")
+        ui.fatal("Root element should have a 'package' tag")
     name = qisys.qixml.parse_required_attr(root, "name")
     version = qisys.qixml.parse_required_attr(root, "version")
     target = qisys.qixml.parse_required_attr(root, "target")

--- a/python/qitoolchain/actions/update.py
+++ b/python/qitoolchain/actions/update.py
@@ -40,7 +40,7 @@ def do(args):
                 mess  = "Could not find feed for toolchain %s\n" % tc_name
                 mess += "Please check configuration or " \
                         "specifiy a feed on the command line\n"
-                raise Exception(mess)
+                ui.fatal(mess)
         toolchain.update(feed, branch=args.branch, name=args.feed_name)
     else:
         tc_names = qitoolchain.get_tc_names()

--- a/python/qitoolchain/binary_package/core.py
+++ b/python/qitoolchain/binary_package/core.py
@@ -15,7 +15,9 @@ All qiBuild packages should have the same layout.
 
 import pprint
 
-class BinaryPackageException(Exception):
+import qisys.error
+
+class BinaryPackageException(qisys.error.Error):
     """Just a custom exception
 
     """
@@ -68,7 +70,7 @@ class BinaryPackage:
             return
         self._load()
         if not "name" in self.metadata:
-            raise Exception("Failed to load package. "
+            raise BinaryPackageException("Failed to load package. "
                             "Expecting at least a 'name' key "
                             "in package metadata")
         self.name = self.metadata["name"]

--- a/python/qitoolchain/binary_package/gentoo.py
+++ b/python/qitoolchain/binary_package/gentoo.py
@@ -12,7 +12,9 @@ http://www.gentoo.org/proj/en/portage/index.xml
 import os
 import re
 
-import qisys
+import qisys.archive
+
+from qitoolchain.binary_package.core import BinaryPackageException
 from qitoolchain.binary_package.core import BinaryPackage
 
 class GentooPackage(BinaryPackage):
@@ -56,7 +58,7 @@ class GentooPackage(BinaryPackage):
         """
         if not os.path.exists(dest_dir):
             mess = 'No such file or directory: %s' % dest_dir
-            raise Exception(mess)
+            raise BinaryPackageException(mess)
         discard_pattern = "trailing garbage after EOF ignored"
         root_dir =  qisys.archive._extract_tar(self.path, dest_dir, algo="bzip2",
                                                  quiet=True, verbose=False,

--- a/python/qitoolchain/database.py
+++ b/python/qitoolchain/database.py
@@ -5,6 +5,7 @@ import os
 
 from qisys import ui
 from qisys.qixml import etree
+import qisys.error
 import qisys.qixml
 import qitoolchain.feed
 import qitoolchain.qipackage
@@ -54,7 +55,7 @@ class DataBase(object):
     def remove_package(self, name):
         """ Remove a package from a database """
         if name not in self.packages:
-            raise Exception("No such package: %s" % name)
+            raise qisys.error.Error("No such package: %s" % name)
         to_remove = self.packages[name]
         qisys.sh.rm(to_remove.path)
         del self.packages[name]
@@ -69,7 +70,7 @@ class DataBase(object):
         res = self.packages.get(name)
         if res is None:
             if raises:
-                raise Exception("No such package: %s" % name)
+                raise qisys.error.Error("No such package: %s" % name)
         return res
 
     def solve_deps(self, packages, dep_types=None):

--- a/python/qitoolchain/feed.py
+++ b/python/qitoolchain/feed.py
@@ -13,9 +13,10 @@ import urlparse
 from xml.etree import ElementTree
 
 from qisys import ui
-import qisys
 import qisys.archive
+import qisys.error
 import qisys.remote
+import qisys.sh
 import qisys.version
 import qisrc.git
 import qibuild.config
@@ -36,7 +37,7 @@ def raise_parse_error(package_tree, feed, message):
     mess  = "Error when parsing feed: '%s'\n" % feed
     mess += "Could not parse:\t%s\n" % as_str
     mess += message
-    raise Exception(mess)
+    raise qisys.error.Error(mess)
 
 def tree_from_feed(feed_location, branch=None, name=None):
     """ Returns an ElementTree object from an
@@ -52,12 +53,13 @@ def tree_from_feed(feed_location, branch=None, name=None):
             if is_url(feed_location):
                 fp = qisys.remote.open_remote_location(feed_location)
             else:
-                raise Exception("Feed location is not an existing path nor an url")
+                raise qisys.error.Error(
+                        "Feed location is not an existing path nor an url")
         tree = ElementTree.ElementTree()
         tree.parse(fp)
-    except Exception:
+    except Exception as e:
         ui.error("Could not parse", feed_location)
-        raise
+        raise qisys.error.Error(str(e))
     finally:
         if fp:
             fp.close()

--- a/python/qitoolchain/parsers.py
+++ b/python/qitoolchain/parsers.py
@@ -1,6 +1,8 @@
 ## Copyright (c) 2012-2016 Aldebaran Robotics. All rights reserved.
 ## Use of this source code is governed by a BSD-style license that can be
 ## found in the COPYING file.
+
+import qisys.error
 import qisys.worktree
 import qibuild.parsers
 
@@ -42,15 +44,15 @@ def get_toolchain(args):
         mess += "current worktree configuration)\n"
         mess += "Please specify a configuration with -c, --config \n"
         mess += "or a toolchain name with -t, --toolchain"
-        raise Exception(mess)
+        raise qisys.error.Error(mess)
 
 
     qibuild_cfg = qibuild.config.QiBuildConfig()
     qibuild_cfg.read()
     build_config = qibuild_cfg.configs.get(config)
     if not build_config:
-        raise Exception("No such config: %s" % config)
+        raise qisys.error.Error("No such config: %s" % config)
     tc_name = build_config.toolchain
     if not tc_name:
-        raise Exception("config %s has no toolchain" % config)
+        raise qisys.error.Error("config %s has no toolchain" % config)
     return qitoolchain.get_toolchain(tc_name)

--- a/python/qitoolchain/qipackage.py
+++ b/python/qitoolchain/qipackage.py
@@ -8,6 +8,7 @@ import zipfile
 
 from qisys import ui
 from qisys.qixml import etree
+import qisys.error
 import qisys.version
 import qisrc.license
 import qibuild.deps
@@ -155,7 +156,7 @@ class QiPackage(object):
                     mess = "Bad mask in %s\n" % mask_path
                     mess += line + "\n"
                     mess += "line should start with 'include' or 'exclude'"
-                    raise Exception(mess)
+                    raise qisys.error.Error(mess)
             return mask
 
     def _install_with_mask(self, destdir, mask):
@@ -284,7 +285,7 @@ def from_xml(element):
     res = QiPackage(None) # need to pass an argument to the ctor
     name = element.get("name")
     if not name:
-        raise Exception("missing 'name' attribute")
+        raise qisys.error.Error("missing 'name' attribute")
     url = element.get("url")
     if element.tag == "svn_package":
         import qitoolchain.svn_package

--- a/python/qitoolchain/qipackage.py
+++ b/python/qitoolchain/qipackage.py
@@ -295,7 +295,11 @@ def from_xml(element):
 
 def from_archive(archive_path):
     archive = zipfile.ZipFile(archive_path)
-    xml_data = archive.read("package.xml")
+    try:
+        xml_data = archive.read("package.xml")
+    except KeyError:
+        raise qisys.error.Error("Could not find package.xml in %s" %
+                                archive_path)
     element = etree.fromstring(xml_data)
     return from_xml(element)
 

--- a/python/qitoolchain/test/test_feed.py
+++ b/python/qitoolchain/test/test_feed.py
@@ -4,6 +4,7 @@
 
 from qitoolchain.feed import *
 
+import qisys.error
 from qisrc.test.conftest import git_server
 
 import pytest
@@ -15,7 +16,7 @@ def test_is_url():
 
 def test_parse_non_exising_path():
     #pylint: disable-msg=E1101
-    with pytest.raises(Exception) as e:
+    with pytest.raises(qisys.error.Error) as e:
         tree_from_feed("does/not/exists")
     assert "not an existing path" in e.value.message
     assert "nor an url" in e.value.message

--- a/python/qitoolchain/test/test_parsers.py
+++ b/python/qitoolchain/test/test_parsers.py
@@ -3,6 +3,7 @@
 ## found in the COPYING file.
 import pytest
 
+import qisys.error
 import qibuild.config
 
 import qitoolchain.parsers
@@ -16,7 +17,7 @@ def test_using_dash_c(toolchains, args):
     assert qitoolchain.parsers.get_toolchain(args) == foo_tc
     args.config = "baz"
     # pylint: disable-msg=E1101
-    with pytest.raises(Exception) as e:
+    with pytest.raises(qisys.error.Error) as e:
         qitoolchain.parsers.get_toolchain(args)
     assert "config baz has no toolchain" in e.value.message
 
@@ -27,4 +28,3 @@ def test_using_defaut_config(toolchains, args, build_worktree):
     build_worktree.set_default_config("foo")
     args.worktree = build_worktree.root
     assert qitoolchain.parsers.get_toolchain(args) == foo_tc
-

--- a/python/qitoolchain/test/test_qitoolchain_add_package.py
+++ b/python/qitoolchain/test/test_qitoolchain_add_package.py
@@ -19,15 +19,16 @@ def test_simple(qitoolchain_action):
     assert world_package.name == "world"
     assert world_package.path
 
-def test_legacy_no_name_given(tmpdir, qitoolchain_action):
+def test_legacy_no_name_given(tmpdir, qitoolchain_action, record_messages):
     qitoolchain_action("create", "foo")
     qibuild.config.add_build_config("foo", toolchain="foo")
     world = tmpdir.mkdir("world")
     world.ensure("include", "world.h", file=True)
     world.ensure("lib", "libworld.so", file=True)
     archive = qisys.archive.compress(world.strpath)
-    error = qitoolchain_action("add-package", "-c", "foo", archive, raises=True)
-    assert "Must specify --name" in error
+    rc = qitoolchain_action("add-package", "-c", "foo", archive, retcode=True)
+    assert rc != 0
+    assert record_messages.find("Must specify --name")
 
 def test_legacy_happy_path(tmpdir, qitoolchain_action):
     qitoolchain_action("create", "foo")

--- a/python/qitoolchain/test/test_qitoolchain_make_package.py
+++ b/python/qitoolchain/test/test_qitoolchain_make_package.py
@@ -31,8 +31,9 @@ def test_create_extract(qitoolchain_action, tmpdir):
     assert package.version == "0.1"
     assert package.target == "linux64"
 
-def test_on_invalid_xml(qitoolchain_action, tmpdir):
+def test_on_invalid_xml(qitoolchain_action, tmpdir, record_messages):
     package_xml = tmpdir.join("package.xml")
     package_xml.write("<foo/>")
-    error = qitoolchain_action("make-package", tmpdir.strpath, raises=True)
-    assert "Root element" in error
+    rc = qitoolchain_action("make-package", tmpdir.strpath, retcode=True)
+    assert rc != 0
+    assert record_messages.find("Root element")

--- a/python/qitoolchain/test/test_qitoolchain_remove.py
+++ b/python/qitoolchain/test/test_qitoolchain_remove.py
@@ -1,6 +1,8 @@
 ## Copyright (c) 2012-2016 Aldebaran Robotics. All rights reserved.
 ## Use of this source code is governed by a BSD-style license that can be
 ## found in the COPYING file.
+
+import qisys.error
 import qibuild.config
 import qitoolchain.toolchain
 
@@ -12,12 +14,12 @@ def test_simple(qitoolchain_action):
     qitoolchain.toolchain.Toolchain("foo")
     qitoolchain_action("remove", "-f", "foo")
     # pylint: disable-msg=E1101
-    with pytest.raises(Exception):
+    with pytest.raises(qisys.error.Error):
         qitoolchain.get_toolchain("foo")
 
 def test_when_not_exists(qitoolchain_action):
     # pylint: disable-msg=E1101
-    with pytest.raises(Exception) as e:
+    with pytest.raises(qisys.error.Error) as e:
         qitoolchain_action("remove", "foo")
     assert "No such toolchain" in str(e.value)
 
@@ -29,7 +31,7 @@ def test_when_is_default(qitoolchain_action):
     qitoolchain_action("remove", "foo", "--force")
     test_build_worktre2 = TestBuildWorkTree()
     # pylint:disable-msg=E1101
-    with pytest.raises(Exception) as e:
+    with pytest.raises(qisys.error.Error) as e:
         test_build_worktre2.toolchain
     assert "No such toolchain" in e.value.message
 

--- a/python/qitoolchain/test/test_qitoolchain_update.py
+++ b/python/qitoolchain/test/test_qitoolchain_update.py
@@ -20,10 +20,11 @@ def test_update_local_ctc(qitoolchain_action, tmpdir):
     qitoolchain_action("update", "ctc", toolchain_xml.strpath)
     assert ctc_path.check(dir=True)
 
-def test_update_no_feed(qitoolchain_action):
+def test_update_no_feed(qitoolchain_action, record_messages):
     qitoolchain_action("create", "foo")
-    error = qitoolchain_action("update", "foo", raises=True)
-    assert "Could not find feed" in error
+    rc = qitoolchain_action("update", "foo", retcode=True)
+    assert rc != 0
+    assert record_messages.find("Could not find feed")
 
 def test_udpate_all_toolchains(qitoolchain_action, feed, record_messages):
     qitoolchain_action("create", "foo", feed.url)

--- a/python/qitoolchain/toolchain.py
+++ b/python/qitoolchain/toolchain.py
@@ -4,6 +4,7 @@
 import os
 
 from qisys import ui
+import qisys.error
 import qisys.sh
 import qisrc.git
 import qitoolchain.database
@@ -109,7 +110,7 @@ class Toolchain(object):
                 lines.append('include("%s")\n' % tc_file)
         for package in self.packages:
             if not package.path:
-                raise Exception(""" \
+                raise qisys.error.Error(""" \
 Incorrect database configuration in %s: no path for package %s
 """ % (self.db.db_path, package.name))
         oldlines = list()


### PR DESCRIPTION
Now all exceptions raised from qibuild inherit from `qisys.error.Error`
    
That way we don't have to output their names when
displaying error messages in `qisys.script.run_action()`
    
As a shortcut, `sys.exit()` and `ui.fatal()` are also available to signal errors and exit from the actions

Everything else is considered as a bug/crash, and the traceback is automatically saved to a temp file

Also, now qitest run displays an additional message if tests fail due to missing DLLs
