### PR TITLE
qipkg: add --no-toolchain-packages

### DIFF
--- a/doc/source/changes/3.12.rst
+++ b/doc/source/changes/3.12.rst
@@ -152,6 +152,14 @@ qidoc
   * ``conf.in.py`` or ``Doxyfile.in``
   * From ``qiproject.xml``
 
+qipkg
+-----
+
+* ``qipkg make-package``: add ``--no-toolchain-packages`` to *not* include
+  packages from toolchain in the generated ``.pkg`` file.
+  Note that this will speed up development, at the cost of generating packages
+  that may no longer work on a different NAOqi version
+
 qisrc
 ------
 

--- a/doc/source/spelling_wordlist.txt
+++ b/doc/source/spelling_wordlist.txt
@@ -229,6 +229,7 @@ qtxmlpatterns
 qxt
 readme
 rebase
+rebased
 rebases
 rebasing
 recurse

--- a/python/qipkg/actions/make_package.py
+++ b/python/qipkg/actions/make_package.py
@@ -13,7 +13,13 @@ def configure_parser(parser):
     """Configure parser for this action"""
     qipkg.parsers.pml_parser(parser)
     parser.add_argument("-o", "--output")
+    parser.add_argument("--no-toolchain-packages", dest="include_tc_packages",
+                        action="store_false",
+                        help="Do not include packages from the toolchain.\n"
+                             "Warning: your .pkg may no longer be compatible "
+                             "with other releases of NAOqi")
     qipkg.parsers.pkg_parser(parser)
+    parser.set_defaults(include_tc_packages=True)
 
 
 def do(args):
@@ -21,5 +27,9 @@ def do(args):
     output = args.output
     with_breakpad = args.with_breakpad
     force = args.force
+    include_tc_packages = args.include_tc_packages
     pml_builder = qipkg.parsers.get_pml_builder(args)
-    return pml_builder.package(output=output, with_breakpad=with_breakpad, force=force)
+    return pml_builder.package(output=output,
+                              with_breakpad=with_breakpad,
+                              force=force,
+                              include_tc_packages=include_tc_packages)

--- a/python/qipkg/builder.py
+++ b/python/qipkg/builder.py
@@ -179,7 +179,7 @@ Error when parsing {pml_path}
         for builder in self.builders:
             builder.build()
 
-    def install(self, destination):
+    def install(self, destination, include_tc_packages=True):
         """ Install every project to the given destination """
         qisys.sh.mkdir(destination, recursive=True)
         # Copy the manifest
@@ -192,7 +192,8 @@ Error when parsing {pml_path}
                 ui.info(ui.bold, "-> Adding %s ..." % desc)
             if isinstance(builder, qibuild.cmake_builder.CMakeBuilder):
                 builder.dep_types=["runtime"]
-                builder.install(destination, components=["runtime"])
+                builder.install(destination, components=["runtime"],
+                                install_tc_packages=include_tc_packages)
             else:
                 builder.install(destination)
 
@@ -216,7 +217,8 @@ Error when parsing {pml_path}
         """ Deploy every project to the given url """
         qisys.remote.deploy(self.stage_path, url)
 
-    def package(self, output=None, with_breakpad=False, force=False):
+    def package(self, output=None, with_breakpad=False, force=False,
+                include_tc_packages=True):
         """ Generate a package containing every project.
 
         :param: with_breakpad generate debug symbols for usage
@@ -243,7 +245,7 @@ Error when parsing {pml_path}
 
 
         # Add everything from the staged path
-        self.install(self.stage_path)
+        self.install(self.stage_path, include_tc_packages=include_tc_packages)
 
         ui.info(ui.bold, "-> Compressing package ...")
         qisys.archive.compress(self.stage_path, output=output, flat=True,

--- a/python/qipkg/metabuilder.py
+++ b/python/qipkg/metabuilder.py
@@ -56,7 +56,8 @@ class MetaPMLBuilder(object):
                     "Deploying", pml_builder.pml_path)
             pml_builder.deploy(url)
 
-    def package(self, with_breakpad=False, output=None, force=False):
+    def package(self, with_breakpad=False, output=None, force=False,
+                include_tc_packages=True):
         """ Generate a package containing every package.
 
         :param: with_breakpad generate debug symbols for usage
@@ -68,7 +69,8 @@ class MetaPMLBuilder(object):
         for i, pml_builder in enumerate(self.pml_builders):
             ui.info(ui.green, "::", ui.reset, ui.bold, "[%i/%i]" % ((i + 1), n),
                     "Making package from", pml_builder.pml_path)
-            packages = pml_builder.package(with_breakpad=with_breakpad, force=force)
+            packages = pml_builder.package(with_breakpad=with_breakpad, force=force,
+                                           include_tc_packages=include_tc_packages)
             if isinstance(packages, list):
                 all_packages.extend(packages)
             else:

--- a/python/qipkg/test/test_qipkg.py
+++ b/python/qipkg/test/test_qipkg.py
@@ -5,12 +5,15 @@ from __future__ import print_function
 
 import os
 import sys
+import zipfile
 
+import qibuild.config
 import qisys.command
 import qisys.error
 import qisys.qixml
 from qisys.qixml import etree
 import qibuild.find
+import qitoolchain.qipackage
 import qipkg.builder
 import qipkg.package
 
@@ -163,6 +166,7 @@ def test_no_worktre_bad_pml(tmpdir, monkeypatch):
         package = qisys.script.run_action("qipkg.actions.make_package", [pml_path.strpath])
     assert "not in a worktree" in error.value.message
 
+# pylint:disable-msg=E1101
 @pytest.mark.skipif(not qisys.command.find_program("lrelease", raises=False),
                     reason="lrelease not found")
 def test_translations(qipkg_action, tmpdir):
@@ -290,3 +294,31 @@ def test_deploy_package_from_pml(qipkg_action, tmpdir):
 
     expected_path = os.path.expanduser("~/d-0.1.pkg")
     assert os.path.exists(expected_path)
+
+def test_no_toolchain_packages(qipkg_action, tmpdir, toolchains):
+    a_proj = qipkg_action.add_test_project("a_cpp")
+    qiproject_xml = a_proj.qiproject_xml
+    with open(qiproject_xml, "w") as fp:
+        fp.write("""
+<qibuild format="3">
+  <qibuild name="a_cpp">
+    <depends runtime="true" names="bar" />
+  </qibuild>
+</qibuild>
+""")
+    a_pml = os.path.join(a_proj.path, "a_cpp.pml")
+    tc = toolchains.create("tc")
+    bar_path = tmpdir.join("bar")
+    bar_path.ensure("lib", "libbar.so", file=True)
+    tc_package = qitoolchain.qipackage.QiPackage("bar", "0.1")
+    tc_package.path = bar_path.strpath
+    tc.add_package(tc_package)
+    qibuild.config.add_build_config("tc", toolchain="tc")
+    qipkg_action("configure", "--config", "tc", a_pml)
+    qipkg_action("build", "--config", "tc", a_pml)
+    pkg = qipkg_action("make-package",
+                        "--config", "tc",
+                        "--no-toolchain-packages",
+                        a_pml)
+    archive = zipfile.ZipFile(pkg)
+    assert "lib/libbar.so" not in [x.filename for x in archive.infolist()]


### PR DESCRIPTION
From the changelog:

This makes it possible to *not* include packages from toolchain in the generated ``.pkg`` file.

This will speed up development, at the cost of generating packages  that may no longer work on a different NAOqi version