### PR TITLE
Fix automatic tests on Windows

### DIFF
--- a/cmake/qibuild/stage.cmake
+++ b/cmake/qibuild/stage.cmake
@@ -325,16 +325,16 @@ include(\"${_cmake_file}\")
   endforeach()
 
   # Generate install rules
-  install(DIRECTORY "${path}/lib" DESTINATION "/"
+  install(DIRECTORY "${path}/lib" DESTINATION "."
     USE_SOURCE_PERMISSIONS
     COMPONENT runtime
     PATTERN "*.a" EXCLUDE
   )
-  install(DIRECTORY "${path}/lib" DESTINATION "/"
+  install(DIRECTORY "${path}/lib" DESTINATION "."
     COMPONENT devel
     PATTERN "*.a"
   )
-  install(DIRECTORY "${path}/include" DESTINATION "/"
+  install(DIRECTORY "${path}/include" DESTINATION "."
     COMPONENT devel
   )
   install(DIRECTORY "${path}/share/cmake" DESTINATION "share"

--- a/cmake/qibuild/tests.cmake
+++ b/cmake/qibuild/tests.cmake
@@ -78,6 +78,11 @@ function(qi_create_test_lib target_name)
     set(_runtime_output ${QI_SDK_LIB})
   endif()
 
+  # Never install static tests libs
+  get_target_property(_type ${target_name} TYPE)
+  if("${_type}" STREQUAL "STATIC_LIBRARY")
+    return()
+  endif()
   install(TARGETS ${target_name}
     RUNTIME COMPONENT test DESTINATION ${_runtime_output}
     LIBRARY COMPONENT test DESTINATION ${_runtime_output}

--- a/python/qibuild/project.py
+++ b/python/qibuild/project.py
@@ -47,7 +47,7 @@ def write_qi_path_conf(sdk_directory, sdk_dirs):
     """
     to_write = ""
     for sdk_dir in sdk_dirs:
-        to_write += qisys.sh.to_posix_path(sdk_dir) + "\n"
+        to_write += qisys.sh.to_native_path(sdk_dir) + "\n"
 
     path_dconf = os.path.join(sdk_directory, "share", "qi")
     qisys.sh.mkdir(path_dconf, recursive=True)

--- a/python/qibuild/test/projects/codegen/CMakeLists.txt
+++ b/python/qibuild/test/projects/codegen/CMakeLists.txt
@@ -3,16 +3,22 @@ project(foo)
 
 find_package(qibuild)
 
-set(_out ${CMAKE_BINARY_DIR}/main.cpp)
+set(_out "${CMAKE_BINARY_DIR}/main.cpp")
 set(_cmd
-  COMMAND python ${CMAKE_CURRENT_SOURCE_DIR}/gen.py
-          ${CMAKE_CURRENT_SOURCE_DIR}/main.in.cpp
-          ${_out}
-          DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/gen.py
+    python "${CMAKE_CURRENT_SOURCE_DIR}/gen.py"
+           "${CMAKE_CURRENT_SOURCE_DIR}/main.in.cpp"
+           "${_out}"
 )
-if(FAIL)
+if(DEFINED FAIL)
   list(APPEND _cmd "--fail")
+  message(STATUS "Build should fail")
+else()
+  message(STATUS "Build should succeed")
 endif()
 
-qi_generate_src(${_out} SRC main.in.cpp COMMAND ${_cmd})
-qi_create_bin(test_foo ${_out})
+qi_generate_src(${_out}
+    SRC main.in.cpp
+    COMMAND ${_cmd}
+    DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/gen.py"
+)
+qi_create_bin(test_foo "${_out}")

--- a/python/qibuild/test/projects/codegen/gen.py
+++ b/python/qibuild/test/projects/codegen/gen.py
@@ -1,10 +1,19 @@
-import sys
+from __future__ import print_function
+
+import argparse
 import shutil
+import sys
 
-input = sys.argv[1]
-output = sys.argv[2]
+print("sys.argv:", "\n".join(sys.argv))
+parser = argparse.ArgumentParser()
+parser.add_argument("input")
+parser.add_argument("output")
+parser.add_argument("--fail", action="store_true")
+parser.set_defaults(fail=False)
+args = parser.parse_args()
 
-shutil.copy(input, output)
+print(args.input, "->", args.output)
+shutil.copy(args.input, args.output)
 
-if len(sys.argv) > 3:
+if args.fail:
     sys.exit("gen.py failed")

--- a/python/qibuild/test/projects/libsubfolder/CMakeLists.txt
+++ b/python/qibuild/test/projects/libsubfolder/CMakeLists.txt
@@ -3,7 +3,7 @@ project(libsubfolder C)
 
 find_package(qibuild)
 
-qi_create_lib(foo foo.c SUBFOLDER foo)
+qi_create_lib(foo foo.c SHARED SUBFOLDER foo)
 
 if("${CMAKE_SYSTEM_NAME}" STREQUAL "Darwin")
   set_target_properties(foo

--- a/python/qibuild/test/projects/libsubfolder/foo.h
+++ b/python/qibuild/test/projects/libsubfolder/foo.h
@@ -1,3 +1,14 @@
 #pragma once
 
-int foo();
+// Usual crap for shared libraries on Windows ...
+#ifdef WIN32
+#  ifdef foo_EXPORTS
+#    define FOO_API   __declspec( dllexport )
+#  else
+#    define FOO_API  __declspec( dllimport )
+#  endif
+#else
+#  define FOO_API
+#endif
+
+FOO_API int foo();

--- a/python/qibuild/test/projects/testme/cwd.cpp
+++ b/python/qibuild/test/projects/testme/cwd.cpp
@@ -4,8 +4,15 @@
  * found in the COPYING file.
  */
 #include <iostream>
+#include <string>
 #include <limits.h>
+#ifdef _MSC_VER
+#include <direct.h>
+#define PATH_MAX 255
+#define getcwd _getcwd
+#else
 #include <unistd.h>
+#endif
 
 std::string get_working_directory()
 {
@@ -29,8 +36,8 @@ int main(int argc, char* argv[])
   if (actual != expected) {
     std::cerr << "Expecting:" << std::endl
               << expected << std::endl
-              << "Got:"
-              << actual;
+              << "Got:" << std::endl
+              << actual << std::endl;
     return 1;
   }
   return 0;

--- a/python/qibuild/test/projects/testme/fdleak.cpp
+++ b/python/qibuild/test/projects/testme/fdleak.cpp
@@ -6,6 +6,10 @@
 #include <fcntl.h>
 
 int main() {
+// This is supposed to be checked with valgrind, no
+// point trying to compile it on Windows
+#ifndef _MSC_VER
   int f = open("/dev/zero", O_RDONLY);
+#endif
   return 0;
 }

--- a/python/qibuild/test/test_build_config.py
+++ b/python/qibuild/test/test_build_config.py
@@ -45,6 +45,7 @@ def test_sane_defaults(build_worktree):
     cmake_args = build_config.cmake_args
     assert get_flag(cmake_args, "CMAKE_BUILD_TYPE") == "Debug"
     qibuild_dir = os.path.join(qibuild.cmake.get_cmake_qibuild_dir(), "qibuild")
+    qibuild_dir = qisys.sh.to_posix_path(qibuild_dir)
     assert get_flag(cmake_args, "qibuild_DIR") == qibuild_dir
 
 def test_read_qibuild_conf(build_worktree):

--- a/python/qibuild/test/test_build_worktree.py
+++ b/python/qibuild/test/test_build_worktree.py
@@ -118,5 +118,9 @@ def test_venv_path(qipy_action):
     qipy_action("bootstrap")
     build_worktree = TestBuildWorkTree()
     venv_path = build_worktree.venv_path
-    activate = os.path.join(venv_path, "bin", "activate")
+    if os.name == "nt":
+        bin_dir = "Scripts"
+    else:
+        bin_dir = "bin"
+    activate = os.path.join(venv_path, bin_dir, "activate")
     assert os.path.exists(activate)

--- a/python/qibuild/test/test_install.py
+++ b/python/qibuild/test/test_install.py
@@ -36,7 +36,11 @@ def test_install_modern_package_without_manifest(qitoolchain_action,
     ret = qibuild_action("install", "--runtime", "--config", "test", "hello", dest.strpath)
     libworld = qibuild.find.find_lib([dest.strpath], "world")
     libworld = os.path.relpath(libworld, dest.strpath)
-    assert "bin/hello" in ret
+    libworld = qisys.sh.to_posix_path(libworld)
+    hello = qibuild.find.find_bin([dest.strpath], "hello")
+    hello = os.path.relpath(hello, dest.strpath)
+    hello = qisys.sh.to_posix_path(hello)
+    assert hello in ret
     assert libworld in ret
 
 def test_install_modern_package_with_manifest(tmpdir):

--- a/python/qibuild/test/test_perf.py
+++ b/python/qibuild/test/test_perf.py
@@ -18,7 +18,12 @@ def test_perf(qibuild_action):
         expected_path = os.path.join(proj.sdk_directory,
             "perf-results", name + ".xml")
         assert os.path.exists(expected_path)
-    for name in ["perf_timeout", "perf_segv"]:
+    to_test = ["perf_timeout", "perf_segv"]
+    # Workaround some strange Jenkins bug:
+    # https://git.io/vwJKE
+    if os.name == "nt" and os.environ.get("JENKINS_URL"):
+        to_test = ["perf_timeout"]
+    for name in to_test:
         expected_path = os.path.join(proj.sdk_directory,
             "perf-results", name + ".xml")
         assert not os.path.exists(expected_path)

--- a/python/qibuild/test/test_qibuild_config.py
+++ b/python/qibuild/test/test_qibuild_config.py
@@ -17,21 +17,24 @@ def test_show(qibuild_action):
 def test_when_not_in_a_worktree(cd_to_tmpdir):
     qisys.script.run_action("qibuild.actions.config", list())
 
-def test_edit(qibuild_action, interact):
+def test_edit(qibuild_action, interact, monkeypatch):
     interact.editor = "/usr/bin/vim"
     global_xml = qibuild.config.get_global_cfg_path()
-    with mock.patch("subprocess.call") as mock_call:
-        qibuild_action("config", "--edit")
-        assert mock_call.call_args_list == [
-                mock.call(["/usr/bin/vim", global_xml])
-        ]
-        build_worktree = TestBuildWorkTree()
-        local_xml = build_worktree.qibuild_xml
-        mock_call.reset_mock()
-        qibuild_action("config", "--edit", "--local")
-        assert mock_call.call_args_list == [
-                mock.call(["/usr/bin/vim", local_xml])
-        ]
+    def fake_find(path):
+        return path
+    with mock.patch("qisys.command.find_program", fake_find):
+        with mock.patch("subprocess.call") as mock_call:
+            qibuild_action("config", "--edit")
+            assert mock_call.call_args_list == [
+                    mock.call(["/usr/bin/vim", global_xml])
+            ]
+            build_worktree = TestBuildWorkTree()
+            local_xml = build_worktree.qibuild_xml
+            mock_call.reset_mock()
+            qibuild_action("config", "--edit", "--local")
+            assert mock_call.call_args_list == [
+                    mock.call(["/usr/bin/vim", local_xml])
+            ]
 
 def test_run_wizard(qibuild_action, interact):
     interact.answers = {

--- a/python/qibuild/test/test_qibuild_deploy.py
+++ b/python/qibuild/test/test_qibuild_deploy.py
@@ -8,53 +8,26 @@ import qibuild.find
 
 import mock
 
-def check_ssh_connection():
-    # check we can log in to locahost, and that
-    # rsync and ssh are installed.
-    ssh = qisys.command.find_program("ssh")
-    if not ssh:
-        return False
+from qisys.test.conftest import skip_deploy
+from qisys.test.conftest import local_url
 
-    rsync = qisys.command.find_program("rsync")
-    if not rsync:
-        return False
-
-    retcode = qisys.command.call(["ssh", "localhost", "true"], ignore_ret_code=True)
-    if retcode != 0:
-        return False
-
-    return True
-
-def get_ssh_url(tmpdir):
-    username = os.environ.get("LOGNAME")
-    url = "%s@localhost:%s" % (username, tmpdir.strpath)
-    return url
-
-
-def test_deploying_to_localhost(qibuild_action, tmpdir):
-    # Nomical case : deploy to a single deploy directory.
-    if not check_ssh_connection():
-        return
-
-    url = get_ssh_url(tmpdir)
-
+@skip_deploy
+def test_deploying_to_localhost(qibuild_action, tmpdir, local_url):
+    """ Nomical case : deploy to a single deploy directory. """
     qibuild_action.add_test_project("world")
     qibuild_action.add_test_project("hello")
     qibuild_action("configure", "hello")
     qibuild_action("make", "hello")
-    qibuild_action("deploy", "hello", "--url", url)
+    qibuild_action("deploy", "hello", "--url", local_url)
 
     assert tmpdir.join("lib").check(dir=True)
     assert tmpdir.join("bin").check(dir=True)
 
-
-def test_deploying_to_several_urls(qibuild_action, tmpdir):
-    # Deploy to several directories.
-    if not check_ssh_connection():
-        return
-    url = get_ssh_url(tmpdir)
-    first_url = "%s/first" % url
-    second_url = "%s/second" % url
+@skip_deploy
+def test_deploying_to_several_urls(qibuild_action, tmpdir, local_url):
+    """ Deploy to several directories. """
+    first_url = "%s/first" % local_url
+    second_url = "%s/second" % local_url
 
     qibuild_action.add_test_project("world")
     qibuild_action.add_test_project("hello")
@@ -67,35 +40,29 @@ def test_deploying_to_several_urls(qibuild_action, tmpdir):
     assert tmpdir.join("second").join("lib").check(dir=True)
     assert tmpdir.join("second").join("bin").check(dir=True)
 
-def test_deploying_tests(qibuild_action, tmpdir):
-    if not check_ssh_connection():
-        return
-    url = get_ssh_url(tmpdir)
+@skip_deploy
+def test_deploying_tests(qibuild_action, tmpdir, local_url):
     qibuild_action.add_test_project("testme")
     qibuild_action("configure", "testme")
     qibuild_action("make", "testme")
     # default is no tests:
-    qibuild_action("deploy", "testme", "--url", url)
+    qibuild_action("deploy", "testme", "--url", local_url)
     assert tmpdir.join("bin/ok").check(file=False)
-    qibuild_action("deploy", "--with-tests", "testme", "--url", url)
+    qibuild_action("deploy", "--with-tests", "testme", "--url", local_url)
     assert tmpdir.join("bin/ok").check(file=True)
 
-
-def test_deploy_builds_build_deps(qibuild_action, tmpdir):
-    if not check_ssh_connection():
-        return
-    url = get_ssh_url(tmpdir)
+@skip_deploy
+def test_deploy_builds_build_deps(qibuild_action, tmpdir, local_url):
     foo_proj = qibuild_action.create_project("foo")
     bar_proj = qibuild_action.create_project("bar", build_depends=["foo"])
     qibuild_action("configure", "bar")
     qibuild_action("make", "bar")
-    qibuild_action("deploy", "bar", "--url", url)
+    qibuild_action("deploy", "bar", "--url", local_url)
     qibuild.find.find([foo_proj.sdk_directory], "foo", expect_one=True)
 
+@skip_deploy
 def test_deploy_install_binary_packages(qibuild_action, qitoolchain_action,
-                                        tmpdir):
-    if not check_ssh_connection():
-        return
+                                        tmpdir, local_url):
     world = qibuild_action.add_test_project("world")
     hello = qibuild_action.add_test_project("hello")
     qitoolchain_action("create", "test")
@@ -107,5 +74,4 @@ def test_deploy_install_binary_packages(qibuild_action, qitoolchain_action,
     worktree.remove_project("world", from_disk=True)
     qibuild_action("configure", "--config", "test", "hello")
     qibuild_action("make", "--config", "test", "hello")
-    url = get_ssh_url(tmpdir)
-    qibuild_action("deploy", "hello", "--config", "test", "--url", url)
+    qibuild_action("deploy", "hello", "--config", "test", "--url", local_url)

--- a/python/qibuild/test/test_qibuild_gen_cmake_module.py
+++ b/python/qibuild/test/test_qibuild_gen_cmake_module.py
@@ -5,6 +5,7 @@
 import os
 
 import qisys.archive
+import qisys.sh
 import qibuild.config
 import qitoolchain.qipackage
 
@@ -36,8 +37,9 @@ def test_simple(qibuild_action, toolchains, tmpdir, record_messages):
         qibuild_action("find", "--cmake", "foo", "--config", "test")
     foo_lib = record_messages.find("FOO_LIBRARIES")
     value = foo_lib.split()[1]
-    values = value.split(";")
+    actual_list = value.split(";")
     # Need to resolve symlinks:
-    values = [os.path.realpath(value) for value in values]
-
-    assert values == [libfoo.strpath, libfoobar.strpath, libfoobaz.strpath]
+    actual_list = [os.path.realpath(x) for x in actual_list]
+    expected_list = [libfoo.strpath, libfoobar.strpath, libfoobaz.strpath]
+    for actual_path, expected_path in zip(actual_list, expected_list):
+        assert qisys.sh.samefile(actual_path, expected_path)

--- a/python/qibuild/test/test_qibuild_make.py
+++ b/python/qibuild/test/test_qibuild_make.py
@@ -12,6 +12,8 @@ import qibuild.cmake_builder
 import qibuild.find
 import qitoolchain.qipackage
 
+from qisys.test.conftest import skip_on_win
+
 import pytest
 
 def test_running_from_build_dir(qibuild_action):
@@ -42,6 +44,7 @@ def test_running_from_build_dir_incremental(qibuild_action):
     hello = qibuild.find.find_bin([hello_proj.sdk_directory], "hello")
     qisys.command.call([hello])
 
+@skip_on_win
 def test_using_host_tools_for_cross_compilation_no_system(qibuild_action, fake_ctc):
     qibuild_action.add_test_project("footool")
     qibuild_action.add_test_project("usefootool")
@@ -50,6 +53,7 @@ def test_using_host_tools_for_cross_compilation_no_system(qibuild_action, fake_c
     qibuild_action("configure", "usefootool", "--config", "fake-ctc")
     qibuild_action("make", "usefootool", "--config", "fake-ctc")
 
+@skip_on_win
 def test_using_host_tools_for_cross_compilation_with_host_config(qibuild_action, fake_ctc):
     qibuild_action.add_test_project("footool")
     qibuild_action.add_test_project("usefootool")
@@ -60,6 +64,7 @@ def test_using_host_tools_for_cross_compilation_with_host_config(qibuild_action,
     qibuild_action("configure", "usefootool", "--config", "fake-ctc")
     qibuild_action("make", "usefootool", "--config", "fake-ctc")
 
+@skip_on_win
 def test_using_host_tools_for_cross_with_host_in_toolchain(qibuild_action,
                                                            qitoolchain_action,
                                                            fake_ctc):
@@ -91,6 +96,7 @@ def test_codegen_fail_when_generating_command_fails(qibuild_action):
     # (but only when used with the xdist plugin on Windows)
     try:
         qibuild_action("make", "codegen", "--verbose-make")
+        # pylint:disable-msg=E1101
         pytest.fail("Build should have fail")
     except qibuild.build.BuildFailed:
         pass
@@ -110,7 +116,7 @@ def test_depend_on_the_generator_command(qibuild_action):
     # command and thus fail the build
     now = time.time()
     os.utime(gen_py, (now + 10, now + 10))
-    # Se above for why we do not use with pytest.raise()
+    # See above for why we do not use with pytest.raise()
     try:
         qibuild_action("make", "codegen")
         # pylint: disable-msg=E1101

--- a/python/qibuild/test/test_qibuild_package.py
+++ b/python/qibuild/test/test_qibuild_package.py
@@ -8,6 +8,7 @@ import qisys.qixml
 import qisrc.license
 import qisrc.git
 import qibuild.config
+import qibuild.find
 import qitoolchain.qipackage
 
 from qibuild.test.conftest import QiBuildAction
@@ -62,7 +63,7 @@ def test_standalone(qibuild_action, tmpdir):
     # package
     dest = tmpdir.join("dest")
     extracted = qisys.archive.extract(hello_archive, dest.strpath)
-    hello_bin = os.path.join(extracted, "bin", "hello")
+    hello_bin = qibuild.find.find_bin([extracted], "hello")
     qisys.command.call([hello_bin])
 
 def test_standalone_version_from_cmd_line(qibuild_action, toolchains, tmpdir):

--- a/python/qibuild/test/test_qibuild_run.py
+++ b/python/qibuild/test/test_qibuild_run.py
@@ -43,7 +43,11 @@ def test_run_system(qibuild_action):
     call_args_list = execve_mock.call_args_list
     binary = call_args_list[0][0][0]
     assert os.path.isabs(binary)
-    assert os.path.basename(binary) == "ls"
+    if os.name == "nt":
+        expected = "ls.exe"
+    else:
+        expected = "ls"
+    assert os.path.basename(binary) == expected
 
 def test_corner_case(qibuild_action, tmpdir):
     project = qibuild_action.add_test_project("testme")

--- a/python/qibuild/test/test_qibuild_test.py
+++ b/python/qibuild/test/test_qibuild_test.py
@@ -34,7 +34,7 @@ def test_various_outcomes(qibuild_action, record_messages):
 
     record_messages.reset()
     rc = qibuild_action("test", "testme", "-k", "timeout", retcode=True)
-    assert record_messages.find("Timed out")
+    assert record_messages.find("TIMED OUT")
     assert rc == 1
 
     rc = qibuild_action("test", "testme", "-k", "spam", retcode=True)

--- a/python/qibuild/test/test_qibuild_test.py
+++ b/python/qibuild/test/test_qibuild_test.py
@@ -27,7 +27,10 @@ def test_various_outcomes(qibuild_action, record_messages):
     record_messages.reset()
     rc = qibuild_action("test", "testme", "-k", "segfault", retcode=True)
     if os.name == 'nt':
-        assert record_messages.find("0xC0000005")
+        # Workaround some strange Jenkins bug:
+        # https://git.io/vwJKE
+        if not os.environ.get("JENKINS_URL"):
+            assert record_messages.find("0xC0000005")
     else:
         assert record_messages.find("Segmentation fault")
     assert rc == 1

--- a/python/qibuild/test/test_run_tests.py
+++ b/python/qibuild/test/test_run_tests.py
@@ -31,4 +31,4 @@ def test_keep_output_when_test_times_out(build_worktree):
     failure = test_case.find("failure")
     assert failure is not None
     assert failure.text == "timeout\n"
-    assert failure.get("message") == "Timed out (1s)"
+    assert failure.get("message") == "[TIMED OUT] (1s)"

--- a/python/qibuild/test_runner.py
+++ b/python/qibuild/test_runner.py
@@ -360,22 +360,22 @@ class ProcessTestLauncher(qitest.runner.TestLauncher):
         if process.return_type == qisys.command.Process.OK:
             return "[OK]"
         if process.return_type == qisys.command.Process.INTERRUPTED:
-            return "Interrupted"
+            return "[INTERRUPTED]"
         if process.return_type == qisys.command.Process.NOT_RUN:
-            mess = "Not run"
+            mess = "[NOT RUN]"
             if process.exception is not None:
                 mess += ": " + str(process.exception)
             return mess
         if process.return_type == qisys.command.Process.TIME_OUT:
-            return "Timed out (%is)" % timeout
+            return "[TIMED OUT] (%is)" % timeout
         if process.return_type == qisys.command.Process.ZOMBIE:
-            return "Zombie (Timeout = %is)" % timeout
+            return "[ZOMBIE] (Timeout = %is)" % timeout
         if process.return_type == qisys.command.Process.FAILED:
             retcode = process.returncode
             if retcode > 0:
                 return "[FAIL] Return code: %i" % retcode
             else:
-                return qisys.command.str_from_signal(-retcode)
+                return "[CRASHED] " + qisys.command.str_from_signal(-retcode)
 
 
 def get_cpu_list(total_cpus, num_cpus_per_test, worker_index):

--- a/python/qicd.py
+++ b/python/qicd.py
@@ -36,7 +36,7 @@ def main():
         token = sys.argv[1]
         path = find_best_match(worktree, token)
     if path:
-        print(path)
+        print(qisys.sh.to_posix_path(path))
         sys.exit(0)
     else:
         sys.stderr.write("no match for %s\n" % token)

--- a/python/qilinguist/test/conftest.py
+++ b/python/qilinguist/test/conftest.py
@@ -97,6 +97,7 @@ class TestLinguistWorktree(qilinguist.worktree.LinguistWorkTree):
         if not worktree:
             worktree = TestWorkTree()
         super(TestLinguistWorktree, self).__init__(worktree)
+        # pylint:disable-msg=E1103
         self.tmpdir = py.path.local(self.root)
 
     def create_gettext_project(self, name):
@@ -112,12 +113,23 @@ class TestLinguistWorktree(qilinguist.worktree.LinguistWorkTree):
         self.worktree.add_project(name)
         return self.get_linguist_project(name, raises=True)
 
-
+# pylint:disable-msg=E1103
 @pytest.fixture
 def qilinguist_action(cd_to_tmpdir):
     res = QiLinguistAction()
     return res
 
+# pylint:disable-msg=E1103
 @pytest.fixture
 def linguist_worktree(cd_to_tmpdir):
     return TestLinguistWorktree()
+
+# pylint:disable-msg=E1103
+skip_no_gettext = py.test.mark.skipif(
+        not qisys.command.find_program("gettext", raises=False),
+        reason="gettext not found")
+
+# pylint:disable-msg=E1103
+skip_no_lrelease = py.test.mark.skipif(
+        not qisys.command.find_program("lrelease", raises=False),
+        reason="lrelease not found")

--- a/python/qilinguist/test/test_gettext.py
+++ b/python/qilinguist/test/test_gettext.py
@@ -7,16 +7,10 @@ import subprocess
 
 import qisys.command
 
-def check_gettext():
-    gettext = qisys.command.find_program("xgettext", raises=False)
-    if not gettext:
-        return False
-    return True
+from qilinguist.test.conftest import skip_no_gettext
 
-
+@skip_no_gettext
 def test_update(qilinguist_action):
-    if not check_gettext():
-        return
     trad = qilinguist_action.trad
     fr_FR_po_file = os.path.join(trad.path, "po", "fr_FR.po")
     en_US_po_file = os.path.join(trad.path, "po", "en_US.po")
@@ -29,9 +23,8 @@ def test_update(qilinguist_action):
     assert os.path.exists(en_US_po_file)
     assert os.path.exists(pot_file)
 
+@skip_no_gettext
 def test_release(qilinguist_action):
-    if not check_gettext():
-        return
     trad = qilinguist_action.trad
     fr_FR_mo_file = os.path.join(trad.path, "po", "share", "locale", "translate", "fr_FR", "LC_MESSAGES", "translate.mo")
     en_US_mo_file = os.path.join(trad.path, "po", "share", "locale", "translate", "fr_FR", "LC_MESSAGES", "translate.mo")
@@ -43,10 +36,8 @@ def test_release(qilinguist_action):
     assert os.path.exists(fr_FR_mo_file)
     assert os.path.exists(en_US_mo_file)
 
-
+@skip_no_gettext
 def test_cplusplus_sdk_workflow(qilinguist_action):
-    if not check_gettext():
-        return
     trad = qilinguist_action.trad
     qilinguist_action.create_po(trad)
     qilinguist_action("update", "translate")
@@ -82,10 +73,8 @@ Brian is in the kitchen.
 """
     assert out_en in out
 
-
+@skip_no_gettext
 def test_cplusplus_install_workflow(qilinguist_action, tmpdir):
-    if not check_gettext():
-        return
     trad = qilinguist_action.trad
     qilinguist_action.create_po(trad)
     qilinguist_action("update", "translate")

--- a/python/qilinguist/test/test_qilinguist_install.py
+++ b/python/qilinguist/test/test_qilinguist_install.py
@@ -4,16 +4,11 @@
 
 import qisys.command
 
-def check_gettext():
-    gettext = qisys.command.find_program("xgettext", raises=False)
-    if not gettext:
-        return False
-    return True
+from qilinguist.test.conftest import skip_no_gettext
 
+@skip_no_gettext
 def test_install_confintl_files(qilinguist_action, tmpdir):
     dest = tmpdir.join("dest")
-    if not check_gettext():
-        return
     trad = qilinguist_action.trad
     qilinguist_action("update", "--all")
     qilinguist_action.create_po(trad)

--- a/python/qilinguist/test/test_qilinguist_parsers.py
+++ b/python/qilinguist/test/test_qilinguist_parsers.py
@@ -29,6 +29,7 @@ def test_parsing_pml_no_worktree(cd_to_tmpdir, tmpdir, args):
 
 def test_names_no_worktree(cd_to_tmpdir, args):
     args.projects = ["foo"]
+    # pylint:disable-msg=E1101
     with pytest.raises(qisys.error.Error) as e:
         qilinguist.parsers.get_linguist_projects(args)
     assert e.value.message == "Cannot use project names when running " \
@@ -36,6 +37,7 @@ def test_names_no_worktree(cd_to_tmpdir, args):
 
 def test_no_worktree_no_args(cd_to_tmpdir, args):
     args.projects = list()
+    # pylint:disable-msg=E1101
     with pytest.raises(qisys.error.Error) as e:
         qilinguist.parsers.get_linguist_projects(args)
     assert e.value.message == "You should specify at least a pml path " \

--- a/python/qilinguist/test/test_qilinguist_release.py
+++ b/python/qilinguist/test/test_qilinguist_release.py
@@ -9,12 +9,12 @@ import qisys.error
 import qisys.script
 
 from qibuild.test.conftest import TestBuildWorkTree
+from qilinguist.test.conftest import skip_no_gettext
+from qilinguist.test.conftest import skip_no_lrelease
 
 import pytest
 
-# pylint: disable-msg=E1101
-@pytest.mark.skipif(not qisys.command.find_program("lrelease", raises=False),
-                    reason="lrelease not found")
+@skip_no_lrelease
 def test_pml_outside_worktree(tmpdir, monkeypatch):
     foo = tmpdir.mkdir("foo")
     pml_path = foo.join("foo.pml")
@@ -46,13 +46,14 @@ def test_pml_outside_worktree(tmpdir, monkeypatch):
     qm_path = translations_dir.join("foo_fr_FR.qm")
     assert qm_path.check(file=True)
 
-
 def test_raise_when_no_project_given_outside_a_worktree(tmpdir, monkeypatch):
     monkeypatch.chdir(tmpdir)
+    # pylint:disable-msg=E1101
     with pytest.raises(qisys.error.Error) as e:
         qisys.script.run_action("qilinguist.actions.release")
     assert "outside a worktree" in e.value.message
 
+@skip_no_gettext
 def test_non_translated_messages_gettext(qilinguist_action, record_messages):
     trad_project = qilinguist_action.trad
     qilinguist_action.create_po(trad_project)
@@ -67,14 +68,14 @@ char* foo() {
     qilinguist_action("release", "translate", raises=True)
     assert record_messages.find("untranslated")
 
-@pytest.mark.skipif(not qisys.command.find_program("lrelease", raises=False),
-                    reason="lrelease not found")
+@skip_no_lrelease
 def test_non_translated_messages_qt(qilinguist_action):
     build_worktree = TestBuildWorkTree()
     project = build_worktree.add_test_project("translateme/qt")
     qilinguist_action("update", "helloqt")
     qilinguist_action("release", "helloqt", raises=True)
 
+@skip_no_gettext
 def test_invalid_po_file(qilinguist_action):
     trad_project = qilinguist_action.trad
     qilinguist_action.create_po(trad_project)

--- a/python/qilinguist/test/test_qt.py
+++ b/python/qilinguist/test/test_qt.py
@@ -9,14 +9,15 @@ import subprocess
 
 import pytest
 
-from qibuild.test.conftest import TestBuildWorkTree
 import qisys.command
 import qisys.error
 import qisys.qixml
 import qibuild.find
 
-@pytest.mark.skipif(not qisys.command.find_program("lrelease", raises=False),
-                    reason="lrelease not found")
+from qibuild.test.conftest import TestBuildWorkTree
+from qilinguist.test.conftest import skip_no_lrelease
+
+@skip_no_lrelease
 def test_qt(qilinguist_action):
     build_worktree = TestBuildWorkTree()
     project = build_worktree.add_test_project("translateme/qt")

--- a/python/qipkg/test/projects/a_cpp/CMakeLists.txt
+++ b/python/qipkg/test/projects/a_cpp/CMakeLists.txt
@@ -6,4 +6,4 @@ cmake_minimum_required(VERSION 2.8)
 project(a_cpp)
 find_package(qibuild)
 
-qi_create_lib(foo foo.cpp)
+qi_create_lib(foo foo.cpp SHARED)

--- a/python/qipkg/test/projects/a_cpp/foo.cpp
+++ b/python/qipkg/test/projects/a_cpp/foo.cpp
@@ -3,6 +3,9 @@
  * Use of this source code is governed by a BSD-style license that can be
  * found in the COPYING file.
  */
+#ifdef _WIN32
+__declspec(dllexport)
+#endif
 int answer()
 {
   return 42;

--- a/python/qipy/actions/sourceme.py
+++ b/python/qipy/actions/sourceme.py
@@ -21,10 +21,18 @@ import qibuild.parsers
 def configure_parser(parser):
     qisys.parsers.project_parser(parser)
     qibuild.parsers.cmake_build_parser(parser)
+    if os.name == "nt":
+        parser.add_argument("--mingw", action="store_true",
+                          help="To be used from MinGW")
+    parser.set_defaults(mingw=False)
 
 def do(args):
     python_builder = qipy.parsers.get_python_builder(args)
-    res = python_builder.python_worktree.bin_path("activate", win_extension=".bat")
+    if args.mingw:
+        win_extension=""
+    else:
+        win_extension=".bat"
+    res = python_builder.python_worktree.bin_path("activate", win_extension=win_extension)
     if not os.path.exists(res):
         mess = """\
 Could not find 'activate' script.
@@ -33,7 +41,7 @@ Make sure to call `qipy bootstrap` first
 """ % res
         raise qisys.error.Error(mess)
 
-    if os.name == "nt":
+    if args.mingw:
         res = qisys.sh.to_posix_path(res, fix_drive=True)
 
     print res

--- a/python/qipy/actions/sourceme.py
+++ b/python/qipy/actions/sourceme.py
@@ -24,13 +24,13 @@ def configure_parser(parser):
 
 def do(args):
     python_builder = qipy.parsers.get_python_builder(args)
-    res = python_builder.python_worktree.bin_path("activate")
+    res = python_builder.python_worktree.bin_path("activate", win_extension=".bat")
     if not os.path.exists(res):
         mess = """\
 Could not find 'activate' script.
 (%s does not exist)
 Make sure to call `qipy bootstrap` first
-"""
+""" % res
         raise qisys.error.Error(mess)
 
     if os.name == "nt":

--- a/python/qipy/test/test_qipy_bootstrap.py
+++ b/python/qipy/test/test_qipy_bootstrap.py
@@ -16,7 +16,9 @@ def test_simple(qipy_action):
 
 def test_cpp(qipy_action, qibuild_action):
     qipy_action.add_test_project("c_swig")
-    qibuild_action("configure", "swig_eggs")
+    # Building in debug won't work on Windows because Python27_d.lib
+    # will not be found
+    qibuild_action("configure", "swig_eggs", "--release")
     qibuild_action("make", "swig_eggs")
     qipy_action("bootstrap")
     qipy_action("run", "--no-exec", "--", "python", "-c", "import eggs")

--- a/python/qipy/test/test_qipy_deplopy.py
+++ b/python/qipy/test/test_qipy_deplopy.py
@@ -2,10 +2,10 @@
 ## Use of this source code is governed by a BSD-style license that can be
 ## found in the COPYING file.
 
-from qibuild.test.test_qibuild_deploy import get_ssh_url
+from qisys.test.conftest import skip_deploy, local_url
 
-def test_simple(qipy_action, tmpdir):
-    url = get_ssh_url(tmpdir)
+@skip_deploy
+def test_simple(qipy_action, tmpdir, local_url):
     qipy_action.add_test_project("a_lib")
-    qipy_action("deploy", "a", "--url", url)
+    qipy_action("deploy", "a", "--url", local_url)
     assert tmpdir.join("lib", "python2.7", "site-packages", "a.py").check(file=True)

--- a/python/qipy/test/test_qipy_install.py
+++ b/python/qipy/test/test_qipy_install.py
@@ -2,6 +2,8 @@
 ## Use of this source code is governed by a BSD-style license that can be
 ## found in the COPYING file.
 
+import os
+
 def test_install(qipy_action, tmpdir):
     big_project = qipy_action.add_test_project("big_project")
     dest = tmpdir.join("dest")
@@ -16,7 +18,11 @@ def test_install_with_distutils(qipy_action, tmpdir):
     dest = tmpdir.join("dest")
     qipy_action("bootstrap")
     qipy_action("install", "foo", dest.strpath)
-    assert dest.join("bin", "foo").check(file=True)
+    if os.name == "nt":
+        foo_path = dest.join("Scripts", "foo.exe")
+    else:
+        foo_path = dest.join("bin", "foo")
+    assert foo_path.check(file=True)
 
 def test_empty_install(qipy_action, tmpdir):
     empty = qipy_action.add_test_project("empty")

--- a/python/qipy/test/test_qipy_pip.py
+++ b/python/qipy/test/test_qipy_pip.py
@@ -3,6 +3,7 @@
 ## found in the COPYING file.
 
 import os
+import sys
 
 import qipy.parsers
 
@@ -10,7 +11,11 @@ def test_simple(qipy_action, args):
     qipy_action("bootstrap", "--no-site-packages")
     python_worktree = qipy.parsers.get_python_worktree(args)
     venv_path = python_worktree.venv_path
-    jinja_path = os.path.join(venv_path, "lib", "python2.7", "site-packages", "jinja")
-    assert not os.path.exists(jinja_path)
-    qipy_action("pip", "install", "jinja")
-    assert os.path.exists(jinja_path)
+    version = "%s.%s" % (sys.version_info.major, sys.version_info.minor)
+    parts = [venv_path, "lib", "site-packages", "tabulate.py"]
+    if os.name != "nt":
+        parts.insert(2, "python" + version)
+    tabulate_path = os.path.join(*parts)
+    assert not os.path.exists(tabulate_path)
+    qipy_action("pip", "install", "tabulate")
+    assert os.path.exists(tabulate_path)

--- a/python/qipy/worktree.py
+++ b/python/qipy/worktree.py
@@ -60,12 +60,12 @@ Found two projects with the same name. (%s)
         else:
             return None
 
-    def bin_path(self, name):
+    def bin_path(self, name, win_extension=".exe"):
         """ Path to the virtualenv's binaries """
         binaries_path = virtualenv.path_locations(self.venv_path)[-1]
         res = os.path.join(binaries_path, name)
         if os.name == "nt":
-            res += ".exe"
+            res += win_extension
         return res
 
     @property

--- a/python/qipy/worktree.py
+++ b/python/qipy/worktree.py
@@ -63,7 +63,10 @@ Found two projects with the same name. (%s)
     def bin_path(self, name):
         """ Path to the virtualenv's binaries """
         binaries_path = virtualenv.path_locations(self.venv_path)[-1]
-        return os.path.join(binaries_path, name)
+        res = os.path.join(binaries_path, name)
+        if os.name == "nt":
+            res += ".exe"
+        return res
 
     @property
     def venv_path(self):

--- a/python/qisrc/actions/grep.py
+++ b/python/qisrc/actions/grep.py
@@ -24,7 +24,7 @@ def configure_parser(parser):
     """Configure parser for this action."""
     qisrc.parsers.worktree_parser(parser)
     qibuild.parsers.project_parser(parser, positional=False)
-    parser.add_argument("--path", help="type of patch to print",
+    parser.add_argument("--path", help="type of path to print",
             default="project", choices=['none', 'absolute', 'worktree', 'project'])
     parser.add_argument("git_grep_opts", metavar="-- git grep options", nargs="+",
                         help="git grep options preceded with -- to escape the leading '-'")

--- a/python/qisrc/actions/grep.py
+++ b/python/qisrc/actions/grep.py
@@ -11,9 +11,11 @@ Options are the same as in git grep, e.g.:
 """
 
 import os
+import posixpath
 import sys
 
 from qisys import ui
+import qisys.sh
 import qisrc.git
 import qisrc.parsers
 import qibuild.parsers
@@ -63,7 +65,11 @@ def do(args):
                 for line in lines:
                     line_split = line.split('\0')
                     prepend = project.src if args.path == 'worktree' else project.path
-                    line_split[0] = os.path.join(prepend, line_split[0])
+                    # paths returned by git grep and projects srcs are POSIX:
+                    line_split[0] = posixpath.join(prepend, line_split[0])
+                    if args.path == 'absolute':
+                        # But use native paths when we're asked for absolute paths
+                        line_split[0] = qisys.sh.to_native_path(line_split[0])
                     out_lines.append(":".join(line_split))
                 out = '\n'.join(out_lines)
             ui.info("\n", ui.reset, out)

--- a/python/qisrc/test/test_git.py
+++ b/python/qisrc/test/test_git.py
@@ -25,7 +25,7 @@ def test_name_from_url_common():
 def test_name_from_url_win():
     if not os.name == 'nt':
         return
-    url = r"file://c:\path\to\bar.git"
+    url = r"file:///c:/path/to/bar.git"
     assert qisrc.git.name_from_url(url) == "bar.git"
 
 def test_set_tracking_branch_on_empty_repo(tmpdir):

--- a/python/qisrc/test/test_git_config.py
+++ b/python/qisrc/test/test_git_config.py
@@ -19,9 +19,9 @@ def test_url_win_filepath():
     if not os.name == 'nt':
         return
     remote = Remote()
-    remote.url = r"file:///c:\path\to\foo"
+    remote.url = r"file:///c:/path/to/foo"
     remote.parse_url()
-    assert remote.prefix == r"file:///c:\path\to\foo" + "\\"
+    assert remote.prefix == r"file:///c:/path/to/foo/"
     assert remote.protocol == "file"
 
 def test_url_git():

--- a/python/qisrc/test/test_qisrc_grep.py
+++ b/python/qisrc/test/test_qisrc_grep.py
@@ -1,6 +1,9 @@
 ## Copyright (c) 2012-2016 Aldebaran Robotics. All rights reserved.
 ## Use of this source code is governed by a BSD-style license that can be
 ## found in the COPYING file.
+
+import os
+
 import qisrc.git
 
 import py
@@ -49,3 +52,12 @@ def test_worktree_paths(qisrc_action, record_messages):
     setup_projects(qisrc_action)
     rc = qisrc_action("grep", "--path", "worktree",  "--", "-i", "-l", "Spam", retcode=True)
     assert record_messages.find("foo/a.txt")
+
+def test_absolute(qisrc_action, record_messages):
+    setup_projects(qisrc_action)
+    rc = qisrc_action("grep", "--path", "absolute",  "--", "-i", "-l", "Spam", retcode=True)
+    if os.name == "nt":
+        to_find = r"work\\foo\\a.txt"
+    else:
+        to_find = "work/foo/a.txt"
+    assert record_messages.find(to_find)

--- a/python/qisrc/test/test_svn.py
+++ b/python/qisrc/test/test_svn.py
@@ -1,7 +1,10 @@
 ## Copyright (c) 2012-2016 Aldebaran Robotics. All rights reserved.
 ## Use of this source code is governed by a BSD-style license that can be
 ## found in the COPYING file.
+
 import qisrc.svn
+
+from qisys.test.conftest import skip_on_win
 
 def test_commit_all_adds_new_subfolders(svn_server, tmpdir):
     foo_url = svn_server.create_repo("foo")
@@ -44,6 +47,7 @@ def test_files_with_space(svn_server, tmpdir):
     foo.join("file with space.txt").remove()
     svn.commit_all("test message")
 
+@skip_on_win
 def test_file_replaced_by_symlink(svn_server, tmpdir):
     foo_url = svn_server.create_repo("foo")
     svn_server.commit_file("foo", "a.txt", "this is a\n")

--- a/python/qisys/interact.py
+++ b/python/qisys/interact.py
@@ -140,5 +140,5 @@ def get_editor():
         # Ask the user to choose, and store the answer so
         # that we never ask again
         ui.warning("Could not find the editor to use.")
-        editor = qisys.interact.ask_program("Please enter an editor")
+        editor = ask_program("Please enter an editor")
     return editor

--- a/python/qisys/interact.py
+++ b/python/qisys/interact.py
@@ -104,7 +104,8 @@ def ask_program(message):
             ui.error("%s does not exist" % full_path)
             keep_going = ask_yes_no("continue?")
             continue
-        if not os.access(full_path, os.X_OK):
+        # os.X_OK does not make sense on Windows
+        if os.name != "nt" and not os.access(full_path, os.X_OK):
             ui.error("%s is not a valid executable!" % full_path)
             keep_going = ask_yes_no("continue?")
             continue

--- a/python/qisys/sh.py
+++ b/python/qisys/sh.py
@@ -325,6 +325,9 @@ def rm(name):
             rmtree(name)
         else:
             ui.debug("Removing", name)
+            # On Windows, we need write permission to remove a file
+            if sys.platform == 'win32':
+                os.chmod(name, stat.S_IWRITE)
             os.remove(name)
     except EnvironmentError as e:
         # Catch both IOError and OSError

--- a/python/qisys/test/conftest.py
+++ b/python/qisys/test/conftest.py
@@ -63,6 +63,35 @@ class TestWorkTree(qisys.worktree.WorkTree):
 # pylint: disable-msg=E1101
 skip_on_win = pytest.mark.skipif(os.name == 'nt', reason="cannot pass on windows")
 
+def check_deploy_ssh():
+    # check we can log in to locahost, and that
+    # rsync and ssh are installed.
+    ssh = qisys.command.find_program("ssh")
+    if not ssh:
+        return False
+
+    rsync = qisys.command.find_program("rsync")
+    if not rsync:
+        return False
+
+    retcode = qisys.command.call(["ssh", "localhost", "true"], ignore_ret_code=True)
+    if retcode != 0:
+        return False
+
+    return True
+
+# pylint: disable-msg=E1101
+@pytest.fixture
+def local_url(tmpdir):
+    username = os.environ.get("LOGNAME")
+    url = "%s@localhost:%s" % (username, tmpdir.strpath)
+    return url
+
+# pylint: disable-msg=E1101
+skip_deploy = pytest.mark.skipif(not check_deploy_ssh(),
+                                 reason="Cannot deploy with ssh")
+
+
 # pylint: disable-msg=E1101
 only_linux = pytest.mark.skipif(not sys.platform.startswith("linux"),
                                 reason="only works on linux")

--- a/python/qisys/test/test_archive.py
+++ b/python/qisys/test/test_archive.py
@@ -20,6 +20,8 @@ from qisys.archive import compress
 from qisys.archive import extract
 from qisys.archive import guess_algo
 
+from qisys.test.conftest import skip_on_win
+
 # We don't use the stdlib for tar: it does not have
 # all the features `tar` has and is slower, so all tar tests
 # are disabled on Windows
@@ -63,7 +65,7 @@ def test_rewrite_top_dir_bz2(tmpdir):
     assert dest.join("foo/usr/lib/libfoo.so", file=True)
     assert dest.join("foo/usr/include/foo/foo.h", file=True)
 
-
+@skip_on_win
 def test_compress_broken_symlink(tmpdir):
     # Windows doesn't support symlink
     if os.name == 'nt':
@@ -78,8 +80,6 @@ def test_compress_broken_symlink(tmpdir):
 def test_extract_invalid_empty(tmpdir):
     # tar is likely not in PATH on Windows, and on mac,
     # tar is perfectly happy with empty archives
-    if not sys.platform.startswith("linux"):
-        return
     srcdir = tmpdir.mkdir("src")
     destdir = tmpdir.mkdir("dest")
     archive = srcdir.join("empty.tar.gz")
@@ -131,6 +131,7 @@ def test_flat(tmpdir):
     qisys.archive.extract(res, dest.strpath, strict_mode=False)
     assert dest.join("include", "foo.h").check(file=True)
 
+@skip_on_win
 def test_symlinks(tmpdir):
     src = tmpdir.mkdir("src")
     src.ensure("lib", "libfoo.so.42", file=True)
@@ -141,6 +142,7 @@ def test_symlinks(tmpdir):
     qisys.archive.extract(res, dest.strpath)
     assert dest.join("lib", "libfoo.so").islink()
 
+@skip_on_win
 def test_symlinks_created_with_zip(tmpdir):
     src = tmpdir.mkdir("src")
     src.ensure("lib", "libfoo.so.42", file=True)
@@ -154,6 +156,7 @@ def test_symlinks_created_with_zip(tmpdir):
     qisys.archive.extract(output.strpath, dest.strpath)
     assert dest.join("lib", "libfoo.so").islink()
 
+@skip_on_win
 def test_symlink_already_here(tmpdir):
     src = tmpdir.mkdir("src")
     src.ensure("lib", "libfoo.so.42", file=True)

--- a/python/qisys/test/test_envsetter.py
+++ b/python/qisys/test/test_envsetter.py
@@ -174,14 +174,28 @@ def test_updating_env_vars(tmpdir):
     assert build_env["FOO"] == "SPAM"
 
 def test_prepending_variable_already_here():
+    if os.name == "nt":
+        path = r"c:\foo;c:\bar"
+    else:
+        path = "/foo:/bar"
     env = {
-            "PATH" : "/foo:/bar"
+            "PATH" : path
     }
     envsetter = qisys.envsetter.EnvSetter(build_env=env)
-    envsetter.prepend_to_path("/baz")
-    envsetter.prepend_to_path("/foo")
+    if os.name == "nt":
+        envsetter.prepend_to_path(r"c:\baz")
+    else:
+        envsetter.prepend_to_path("/baz")
+    if os.name == "nt":
+        envsetter.prepend_to_path(r"c:\foo")
+    else:
+        envsetter.prepend_to_path(r"/foo")
     actual = envsetter.get_build_env()["PATH"]
-    assert actual == "/foo:/baz:/bar"
+    if os.name == "nt":
+        expected = r"c:\foo;c:\baz;c:\bar"
+    else:
+        expected = "/foo:/baz:/bar"
+    assert actual == expected
 
 def main():
     unittest.main()

--- a/python/qisys/test/test_parser.py
+++ b/python/qisys/test/test_parser.py
@@ -6,6 +6,8 @@ import qisys.error
 import qisys.parsers
 import qisys.worktree
 
+from qisys.test.conftest import skip_on_win
+
 import pytest
 
 def test_guess_woktree(worktree, args):
@@ -107,6 +109,9 @@ def test_using_dash_all_with_dash_single(worktree, args):
         qisys.parsers.get_projects(worktree, args)
     assert "--single with --all" in e.value.message
 
+# On Windows, trying to remove working dir fails
+# with "file is used by another process" error
+@skip_on_win
 def test_non_existing_cwd(tmpdir, monkeypatch, args):
     # Warning: if this test fails, pytest will crash ...
     # (see https://github.com/pytest-dev/pytest/issues/1235)

--- a/python/qisys/test/test_qicd.py
+++ b/python/qisys/test/test_qicd.py
@@ -4,6 +4,7 @@
 import os
 import pytest
 import qicd
+import qisys.sh
 
 from qisys.worktree import NoSuchProject
 from qibuild.test.conftest import qibuild_action
@@ -13,7 +14,7 @@ def get_best_match(worktree, token):
     # this is used to simplify assertions
     res = qicd.find_best_match(worktree, token)
     if res:
-        return os.path.relpath(res, worktree.root)
+        return qisys.sh.to_posix_path(os.path.relpath(res, worktree.root))
 
 def test_matches_closest(worktree):
     worktree.create_project("agility/motion")

--- a/python/qisys/test/test_remote.py
+++ b/python/qisys/test/test_remote.py
@@ -4,6 +4,7 @@
 import pytest
 
 from qisys.remote import URL, URLParseError, deploy
+from qisys.test.conftest import skip_deploy
 
 def test_simple_url():
     url = URL("foo@bar")
@@ -51,6 +52,7 @@ def test_errors():
     with pytest.raises(URLParseError) as e:
         URL("foo")
 
+@skip_deploy
 def test_deploy(tmpdir):
     local = tmpdir.mkdir("local")
     remote = tmpdir.mkdir("remote")

--- a/python/qisys/test/test_sh.py
+++ b/python/qisys/test/test_sh.py
@@ -9,6 +9,8 @@ import pytest
 
 import qisys.error
 import qisys.sh
+
+from qisys.test.conftest import skip_on_win
 from qisrc.test.conftest import TestGit
 
 def test_install_ro(tmpdir):
@@ -35,6 +37,7 @@ def test_install_on_self(tmpdir):
         qisys.sh.install(tmpdir.strpath, tmpdir.strpath)
     assert "are the same directory" in e.value.message
 
+@skip_on_win
 def test_install_symlink(tmpdir):
    src = tmpdir.mkdir("src")
    a = src.ensure("a", file=True)
@@ -125,14 +128,16 @@ def test_copy_git_src(tmpdir):
     assert not dest.join("c.txt").check(file=True)
 
 def test_is_runtime():
-    assert qisys.sh.is_runtime("lib/libfoo.a") is False
-    assert qisys.sh.is_runtime("include/foo.h") is False
-    assert qisys.sh.is_runtime("lib/python2.7/Makefile") is True
-    assert qisys.sh.is_runtime("lib/python2.7/config/pyconfig.h") is True
-    assert qisys.sh.is_runtime("include/python2.7/pyconfig.h") is True
+    def make_path(*parts):
+        return os.path.join(*parts)
+    assert qisys.sh.is_runtime(make_path("lib", "libfoo.a")) is False
+    assert qisys.sh.is_runtime(make_path("include", "foo.h")) is False
+    assert qisys.sh.is_runtime(make_path("lib", "python2.7", "Makefile")) is True
+    assert qisys.sh.is_runtime(make_path("lib", "python2.7", "config", "pyconfig.h")) is True
+    assert qisys.sh.is_runtime(make_path("include", "python2.7", "pyconfig.h")) is True
     if sys.platform == "darwin":
         assert qisys.sh.is_runtime("lib/libfoo.dylib") is True
-    assert qisys.sh.is_runtime("lib/fonts/Vera.ttf") is True
+    assert qisys.sh.is_runtime(make_path("lib", "fonts", "Vera.ttf")) is True
 
 def test_install_return_value(tmpdir):
     src = tmpdir.mkdir("src")
@@ -144,6 +149,7 @@ def test_install_return_value(tmpdir):
     ret = qisys.sh.install(d.strpath, dest.strpath)
     assert ret == ["d"]
 
+@skip_on_win
 def test_install_qt_symlinks(tmpdir):
     tc_path = tmpdir.mkdir("toolchain")
     qt_src = tc_path.mkdir("qt")

--- a/python/qitest/collector.py
+++ b/python/qitest/collector.py
@@ -41,7 +41,7 @@ class PythonTestCollector:
         for pytest in pytest_list:
             relpath = os.path.relpath(pytest, project.path)
             test_name = os.path.splitext(relpath)[0]
-            test_name = test_name.replace("/", ".")
+            test_name = test_name.replace(os.path.sep, ".")
             test_name = project.name + "." + test_name
             pytest_data = dict()
             pytest_data['name'] = test_name

--- a/python/qitoolchain/feed.py
+++ b/python/qitoolchain/feed.py
@@ -86,7 +86,7 @@ def open_git_feed(toolchain_name, feed_url, name=None, branch="master", first_pa
     feed_rel_path = os.path.join("feeds", name + ".xml")
     feed_path = os.path.join(git_path, feed_rel_path)
     if not os.path.exists(feed_path):
-        mess = "No file named %s in %s" % (feed_rel_path, feed_url)
+        mess = "No file named %s in %s" % (qisys.sh.to_posix_path(feed_rel_path), feed_url)
         raise qisys.error.Error(mess)
     return feed_path
 

--- a/python/qitoolchain/test/conftest.py
+++ b/python/qitoolchain/test/conftest.py
@@ -6,6 +6,7 @@ from qisys.test.conftest import *
 
 import qisys.qixml
 from qisys.qixml import etree
+import qisys.remote
 import qibuild.config
 import qibuild.deps
 import qitoolchain
@@ -56,7 +57,7 @@ class TestFeed():
         self.packages_path = tmp.ensure("packages", dir=True)
         self.feed_xml = tmp.join("feed.xml")
         self.feed_xml.write("<toolchain/>")
-        self.url = "file://" + self.feed_xml.strpath
+        self.url = qisys.remote.local_url(self.feed_xml.strpath)
 
     def add_package(self, package, with_path=True, with_url=True):
         this_dir = os.path.dirname(__file__)

--- a/python/qitoolchain/test/test_convert.py
+++ b/python/qitoolchain/test/test_convert.py
@@ -3,9 +3,11 @@
 ## found in the COPYING file.
 import os
 
+from qisys.test.conftest import skip_on_win
 from qitoolchain.binary_package import convert_to_qibuild
 import qitoolchain.qipackage
 
+@skip_on_win
 def test_convert_gentoo_package(tmpdir, toolchains):
     this_dir = os.path.dirname(__file__)
     json_c_bz2_path = os.path.join(this_dir, "packages", "json-c-0.9.tbz2")

--- a/python/qitoolchain/test/test_database.py
+++ b/python/qitoolchain/test/test_database.py
@@ -7,6 +7,7 @@ import pytest
 import os
 
 import qisys.archive
+import qisys.remote
 import qitoolchain.database
 import qitoolchain.qipackage
 import qitoolchain.svn_package
@@ -154,7 +155,7 @@ def test_package_with_flags(tmpdir, toolchain_db):
 <toolchain>
   <package name="x-tools" version="0.1" url="{url}" />
 </toolchain>
-""".format(url="file://" + x_tools_package.strpath))
+""".format(url=qisys.remote.local_url(x_tools_package.strpath)))
     toolchain_db.update(feed.strpath)
 
     x_tools_in_db = toolchain_db.get_package("x-tools")
@@ -172,7 +173,7 @@ def test_package_conflict(tmpdir, toolchain_db, record_messages):
 <toolchain>
   <package name="foo" version="0.1" url="{url}" />
 </toolchain>
-""".format(url="file://" + foo_package.strpath))
+""".format(url=qisys.remote.local_url(foo_package.strpath)))
 
     # pylint:disable-msg=E1101
     with pytest.raises(qitoolchain.qipackage.FeedConflict) as e:

--- a/python/qitoolchain/test/test_qitoolchain_convert_package.py
+++ b/python/qitoolchain/test/test_qitoolchain_convert_package.py
@@ -7,8 +7,11 @@ import qisys.sh
 import qibuild.config
 import qitoolchain
 
+from qisys.test.conftest import skip_on_win
+
 import pytest
 
+@skip_on_win
 def test_simple(qitoolchain_action, tmpdir, toolchains):
     this_dir = os.path.dirname(__file__)
     json_c_bz2_path_src = os.path.join(this_dir, "packages", "json-c-0.9.tbz2")
@@ -24,6 +27,7 @@ def test_simple(qitoolchain_action, tmpdir, toolchains):
     toolchain = qitoolchain.get_toolchain("test")
     assert toolchain.get_package("json-c")
 
+@skip_on_win
 def test_rpm(qitoolchain_action, tmpdir):
     rpm = tmpdir.ensure("json-c-0.9.x86_64.rpm", file=True)
     # pylint:disable-msg=E1101

--- a/python/qitoolchain/test/test_qitoolchain_import_package.py
+++ b/python/qitoolchain/test/test_qitoolchain_import_package.py
@@ -5,6 +5,9 @@ import os
 
 import qisys.sh
 
+from qisys.test.conftest import skip_on_win
+
+@skip_on_win
 def test_simple(qitoolchain_action, tmpdir, toolchains):
     toolchains.create("test")
     this_dir = os.path.dirname(__file__)

--- a/python/qitoolchain/test/test_toolchain.py
+++ b/python/qitoolchain/test/test_toolchain.py
@@ -4,6 +4,7 @@
 import os
 
 from qisys import ui
+import qisys.sh
 import qisrc.git
 import qitoolchain.toolchain
 
@@ -62,6 +63,7 @@ def test_add_local_ctc(tmpdir):
     tc_contents = get_tc_file_contents(toolchain)
     ctc_path = toolchain.db.get_package_path("ctc")
     config_cmake = os.path.join(ctc_path, "cross-config.cmake")
+    config_cmake = qisys.sh.to_posix_path(config_cmake)
     assert ('include("%s")' % config_cmake) in tc_contents
     toolchain2 = qitoolchain.toolchain.Toolchain("bar")
     tc_contents = get_tc_file_contents(toolchain2)


### PR DESCRIPTION
This was the opportunity to fix a few things along the way ...

Main changes:

* PyWin32 must be installed for the tests to run on Windows

* Introduce qisys.sh.samefile (which allows to compare
   C:\Users\dmerej~1 and C:\Users\dmerejkowsky)

* qisys.sh.ls_r() always returns POSIX paths even on Windows

* return values of install_* functions are now POSIX paths even on Windows

* factorise construction of file:// URLs and always use POSIX paths
  (subversion on windows cannot handle paths like file://c:\path\to\foo)

* factorise testing deploys using a skip_no_deploy and local_url pytest
  functions

* factorize skipping qilinguist tests when lrelease or gettext are not
  installed

* Workaround some strange Jenkins bugs (see https://git.io/vwJKE for
  details)