### PR TITLE
qisys.sh.install: use filecmp to skip if same file already installed

### DIFF
--- a/python/qisys/sh.py
+++ b/python/qisys/sh.py
@@ -18,6 +18,7 @@ import tempfile
 import subprocess
 import ntpath
 import posixpath
+import filecmp
 
 import qisys.error
 from qisys import ui
@@ -265,6 +266,9 @@ def install(src, dest, filter_fun=None, quiet=False):
         mkdir(os.path.dirname(dest), recursive=True)
         if sys.stdout.isatty() and not quiet:
             print "-- Installing %s" % dest
+        if os.path.isfile(dest) and filecmp.cmp(src, dest):
+            ui.info("Up-to-date", dest)
+            return [dest]
         # We do not want to fail if dest exists but is read only
         # (following what `install` does, but not what `cp` does)
         rm(dest)

--- a/python/qisys/test/test_sh.py
+++ b/python/qisys/test/test_sh.py
@@ -163,3 +163,12 @@ def test_to_posix_path():
    assert qisys.sh.to_posix_path(r"c:\foo\bar") ==  "c:/foo/bar"
    assert qisys.sh.to_posix_path(r"foo//bar") == "foo/bar"
    assert qisys.sh.to_posix_path(r"c:\foo\bar", fix_drive=True) == "/c/foo/bar"
+
+def test_install_twice(tmpdir, record_messages):
+    src_file = tmpdir.join("a")
+    src_file.write("data")
+    dest_file = tmpdir.join("b")
+    dest_file.write("data")
+    qisys.sh.install(src_file.strpath, dest_file.strpath)
+    qisys.sh.install(src_file.strpath, dest_file.strpath)
+    assert record_messages.find("Up-to-date")


### PR DESCRIPTION
Might improve performance when re-installing on Windows (DLLs copy use this code)
The default behavior (installation using CMake component install) already does a similar check
