### PR TITLE
Fix for issue #73 ('qibuild make used with -J does not have correct exit code')

### DIFF
--- a/python/qibuild/test/projects/with_compile_error/CMakeLists.txt
+++ b/python/qibuild/test/projects/with_compile_error/CMakeLists.txt
@@ -1,0 +1,11 @@
+## Copyright (c) 2012-2016 Aldebaran Robotics. All rights reserved.
+## Use of this source code is governed by a BSD-style license that can be
+## found in the COPYING file.
+cmake_minimum_required(VERSION 2.8)
+project(with_compile_error)
+
+find_package(qibuild)
+qi_sanitize_compile_flags()
+
+qi_create_bin(foo "main.cpp")
+

--- a/python/qibuild/test/projects/with_compile_error/main.cpp
+++ b/python/qibuild/test/projects/with_compile_error/main.cpp
@@ -1,0 +1,10 @@
+/*
+ * Copyright (c) 2012-2016 Aldebaran Robotics. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the COPYING file.
+ */
+
+int main()
+{
+  return toto;
+}

--- a/python/qibuild/test/projects/with_compile_error/qiproject.xml
+++ b/python/qibuild/test/projects/with_compile_error/qiproject.xml
@@ -1,0 +1,1 @@
+<project name="with_compile_error" />

--- a/python/qibuild/test/test_parallel_builder.py
+++ b/python/qibuild/test/test_parallel_builder.py
@@ -1,4 +1,7 @@
 import qibuild.parallel_builder
+import qibuild.build
+
+import pytest
 
 class FakeProject(object):
     build_log = list()
@@ -29,3 +32,14 @@ def test_simple():
     build_log = FakeProject.build_log
     assert is_before(build_log, "a", "c")
     assert is_before(build_log, "b", "c")
+
+def test_running_build_with_compilation_errors_fails(qibuild_action):
+    # Running `qibuild make -J1` on a c++ project with compilation
+    # errors should fail
+
+    qibuild_action.add_test_project("with_compile_error")
+    qibuild_action("configure", "with_compile_error")
+
+    # pylint: disable-msg=E1101
+    with pytest.raises(qibuild.build.BuildFailed):
+        qibuild_action("make", "-J1", "with_compile_error")


### PR DESCRIPTION
Hello,
as discussed with Dimitri, here is the fix for parallel builder when the last (or the only) job fails.
In this case, the error has not been correctly detected.
Includes the test for this specific case.
Igor