### PR TITLE
qisrc push: don't try to set reviewers when --no-review #97

### DIFF
--- a/python/qisrc/actions/push.py
+++ b/python/qisrc/actions/push.py
@@ -65,14 +65,16 @@ def do(args):
     if git_project.review:
         maintainers = qisrc.maintainers.get(git_project, warn_if_none=True)
         orphaned = any(x["name"] == "ORPHANED" for x in maintainers)
-        if orphaned:
+        if not args.review:
+            reviewers = list()
+        elif orphaned:
             ui.warning("Project is orphaned, no reviewers set")
             reviewers = list()
         else:
             reviewers = [x['email'] for x in maintainers]
             reviewers.extend(args.reviewers or list())
-        # Prefer gerrit logins or groups instead of e-mails
-        reviewers = [x.split("@")[0] for x in reviewers]
+            # Prefer gerrit logins or groups instead of e-mails
+            reviewers = [x.split("@")[0] for x in reviewers]
         qisrc.review.push(git_project, local_ref, remote_branch,
                           bypass_review=(not args.review),
                           dry_run=args.dry_run, reviewers=reviewers,


### PR DESCRIPTION
There was some logic missing here, this option is seldom used
and needed a test