### PR TITLE
Limit IPython package version to comply with python 2.7 compatibility

### DIFF
--- a/python/qipy/actions/bootstrap.py
+++ b/python/qipy/actions/bootstrap.py
@@ -24,7 +24,8 @@ def configure_parser(parser):
                              "directory")
     parser.add_argument("-p", "--python",
                         help="The Python interpreter to use")
-    parser.set_defaults(requirements=["pip", "virtualenv", "ipython"],
+    # Limit IPython package version to comply with python 2.7 compatibility
+    parser.set_defaults(requirements=["pip", "virtualenv", "ipython<6"],
                         site_packages=True)
 
 def do(args):


### PR DESCRIPTION
This PR intends to fix the broken units tests as described in issue https://github.com/aldebaran/qibuild/issues/110