### PR TITLE
Fix using -l and -i in qisrc grep options #91

### DIFF
--- a/python/qisrc/test/test_qisrc_grep.py
+++ b/python/qisrc/test/test_qisrc_grep.py
@@ -49,6 +49,10 @@ def test_using_git_grep_options(qisrc_action, record_messages):
     rc = qisrc_action("grep", "--", "-i", "-l", "Spam", retcode=True)
     assert rc == 0
     assert record_messages.find("a.txt")
+    # Simple use of -l or -i args (GitHub issue #91)
+    rc = qisrc_action("grep", "Spam", "--", "-i", "-l", retcode=True)
+    assert rc == 0
+    assert record_messages.find("a.txt")
 
 
 def test_worktree_paths(qisrc_action, record_messages):


### PR DESCRIPTION
Move these options to the `grep` command and remove them from the options
Then concat the grep command and the options before calling Git!

When I looked at the tests I noticed that there was a workaround, putting everything after `qisrc grep --`.
After this fix, both ways will work.